### PR TITLE
Tests For Port Layer

### DIFF
--- a/altos-rust/Makefile
+++ b/altos-rust/Makefile
@@ -14,7 +14,7 @@ release_static_lib = target/$(target)/release/$(static_lib)
 release_build_path = $(build_path)release/
 release_build = $(release_build_path)$(binary)
 
-path_to_cm0 = port/cortex-m0/Cargo.toml
+path_to_cm0 = port/cortex-m0/
 
 ### CARGO ###
 cargo = xargo
@@ -84,7 +84,8 @@ test:
 	@#	feature flag enabled for our core build, so we need to compile and run the
 	@#	tests for the port layer seperately... I think? I'm not sure, this requires
 	@#	more research but doing this works for now.
-	@$(cargo) test --manifest-path $(path_to_cm0)
+	@$(cargo) test --manifest-path $(path_to_cm0)Cargo.toml
+	@rm -rf $(path_to_cm0)target $(path_to_cm0)Cargo.lock
 
 test_verbose:
 	@$(cargo) test $(test_args) -- --nocapture

--- a/altos-rust/Makefile
+++ b/altos-rust/Makefile
@@ -14,6 +14,8 @@ release_static_lib = target/$(target)/release/$(static_lib)
 release_build_path = $(build_path)release/
 release_build = $(release_build_path)$(binary)
 
+path_to_cm0 = port/cortex-m0/Cargo.toml
+
 ### CARGO ###
 cargo = xargo
 cargo_args = --target $(target)
@@ -23,14 +25,15 @@ test_dependencies = altos_core \
 										arm \
 										volatile \
 										cm0_atomic \
+										#cortex_m0 \
 
-# --lib flag only runs the unit test suite, doc tests are currently and issue for cross-compiled 
+# --lib flag only runs the unit test suite, doc tests are currently and issue for cross-compiled
 #  platforms. See: https://github.com/rust-lang/cargo/issues/1789
 test_args = $(foreach dep, $(test_dependencies),-p $(dep)) --lib
 
 ### LINKER ###
 linker = arm-none-eabi-ld
-linker_args = -n --gc-sections -T $(linker_script) 
+linker_args = -n --gc-sections -T $(linker_script)
 
 ### SIZE ###
 size = arm-none-eabi-size
@@ -38,7 +41,7 @@ size_flags = -t
 
 ### GDB ###
 gdb = arm-none-eabi-gdb
-gdb_flags = 
+gdb_flags =
 st_port = 4242
 ocd_port = 3333
 st_gdb_flags = $(gdb_flags) -eval-command="target remote :$(st_port)"
@@ -68,7 +71,7 @@ release: $(linker_script)
 
 gdb: debug
 	@$(gdb) $(gdb_flags) $(debug_build)
-	
+
 gdb-st: debug
 	@$(gdb) $(st_gdb_flags) $(debug_build)
 
@@ -77,6 +80,11 @@ gdb-ocd: debug
 
 test:
 	@$(cargo) test $(test_args)
+	@#FIXME: when running with the spec flag we don't seem to build with the 'test'
+	@#	feature flag enabled for our core build, so we need to compile and run the
+	@#	tests for the port layer seperately... I think? I'm not sure, this requires
+	@#	more research but doing this works for now.
+	@$(cargo) test --manifest-path $(path_to_cm0)
 
 test_verbose:
 	@$(cargo) test $(test_args) -- --nocapture

--- a/altos-rust/altos-core/Cargo.toml
+++ b/altos-rust/altos-core/Cargo.toml
@@ -7,10 +7,12 @@ authors = ["Daniel Seitz <dnseitz@gmail.com>"]
 crate-type = ["rlib"]
 
 [features]
-default = ["bump_alloc"]
+default = []
 
 bump_alloc = ["bump_allocator"]
+default_alloc = []
 cm0 = []
+test = []
 
 [dependencies]
 bump_allocator = { path = "libs/heap/bump_allocator", optional = true }

--- a/altos-rust/altos-core/src/arch/cm0.rs
+++ b/altos-rust/altos-core/src/arch/cm0.rs
@@ -69,11 +69,16 @@ pub fn in_kernel_mode() -> bool {
   const _PROGRAM_STACK: usize = 0b10;
   unsafe {
     let stack_mask: usize;
+    #[cfg(target_arch="arm")]
     asm!("mrs $0, CONTROL\n" /* get the stack control mask */
       : "=r"(stack_mask)
       : /* no inputs */
       : /* no clobbers */
       : "volatile");
+    #[cfg(not(target_arch="arm"))]
+    {
+      stack_mask = 0;
+    }
     stack_mask == MAIN_STACK
   }
 }
@@ -81,6 +86,7 @@ pub fn in_kernel_mode() -> bool {
 pub fn begin_critical() -> usize {
   let primask: usize;
   unsafe {
+    #[cfg(target_arch="arm")]
     asm!(
       concat!(
         "mrs $0, PRIMASK\n",
@@ -89,6 +95,10 @@ pub fn begin_critical() -> usize {
       : /* no inputs */
       : /* no clobbers */
       : "volatile");
+  }
+  #[cfg(not(target_arch="arm"))]
+  {
+    primask = 0;
   }
   primask
 }

--- a/altos-rust/altos-core/src/arch/unknown.rs
+++ b/altos-rust/altos-core/src/arch/unknown.rs
@@ -1,0 +1,44 @@
+// arch/unknown.rs
+// AltOS Rust
+//
+// Created by Daniel Seitz on 1/7/17
+
+//! This module is used to provide stubs for the architecture layer
+
+use volatile::Volatile;
+use task::args::Args;
+use alloc::boxed::Box;
+use sched;
+
+extern "Rust" {
+  fn __yield_cpu();
+  fn __initialize_stack(stack_ptr: Volatile<usize>, code: fn(&mut Args), args: &Box<Args>) -> usize;
+  fn __start_first_task();
+  fn __in_kernel_mode() -> bool;
+  fn __begin_critical() -> usize;
+  fn __end_critical(mask: usize);
+}
+
+pub fn yield_cpu() {
+  unsafe { __yield_cpu() };
+}
+
+pub fn initialize_stack(stack_ptr: Volatile<usize>, code: fn(&mut Args), args: &Box<Args>) -> usize {
+  unsafe { __initialize_stack(stack_ptr, code, args) }
+}
+
+pub fn start_first_task() {
+  unsafe { __start_first_task() };
+}
+
+pub fn in_kernel_mode() -> bool {
+  unsafe { __in_kernel_mode() }
+}
+
+pub fn begin_critical() -> usize {
+  unsafe { __begin_critical() }
+}
+
+pub fn end_critical(mask: usize) {
+  unsafe { __end_critical(mask) };
+}

--- a/altos-rust/altos-core/src/init.rs
+++ b/altos-rust/altos-core/src/init.rs
@@ -5,7 +5,7 @@
 
 // FIXME: Try to see if there's a better way to handle this for testing
 // We do this cfg for testing purposes, this allows doctests to run without any compilation errors.
-#![cfg(not(test))]
+#![cfg(all(not(test), not(feature="test"), feature="bump_allocator"))]
 
 //! Contains functions used for initialization of the kernel
 

--- a/altos-rust/altos-core/src/lib.rs
+++ b/altos-rust/altos-core/src/lib.rs
@@ -26,7 +26,7 @@
 #[macro_use]
 extern crate std;
 
-#[cfg(all(not(test), feature="bump_allocator"))]
+#[cfg(all(not(test), not(feature="test"), feature="bump_allocator"))]
 extern crate bump_allocator as allocator;
 
 pub extern crate alloc;
@@ -43,8 +43,12 @@ mod test;
 #[path = "arch/cm0.rs"]
 mod arch;
 
-#[cfg(test)]
+#[cfg(any(test, feature="test"))]
 #[path = "arch/test.rs"]
+mod arch;
+
+#[cfg(all(not(feature="test"), not(feature="cm0")))]
+#[path = "arch/unknown.rs"]
 mod arch;
 
 pub mod tick;

--- a/altos-rust/port/cortex-m0/Cargo.toml
+++ b/altos-rust/port/cortex-m0/Cargo.toml
@@ -6,13 +6,20 @@ authors = ["Daniel Seitz <dnseitz@gmail.com>"]
 [lib]
 crate-type = ["rlib"]
 
+#[dev-dependencies]
+#volatile = { path = "../../libs/volatile" }
+[dev-dependencies.altos_core]
+path = "../../altos-core"
+features = ["test"]
+
 [dependencies]
 #compiler_builtins = { git = "https://github.com/rust-lang-nursery/compiler-builtins" }
 arm = { path = "libs/arm" }
 
 [dependencies.altos_core]
 path = "../../altos-core"
-features = ["cm0"]
+features = ["bump_allocator", "cm0"]
+#optional = true
 
 #[dependencies.compiler_builtins]
 #git = "https://github.com/rust-lang-nursery/compiler-builtins"

--- a/altos-rust/port/cortex-m0/src/interrupt/enable.rs
+++ b/altos-rust/port/cortex-m0/src/interrupt/enable.rs
@@ -12,7 +12,7 @@ pub struct EnableControl {
 }
 
 impl EnableControl {
-  pub fn new(base_addr: u32) -> Self {
+  pub fn new(base_addr: *const u32) -> Self {
     EnableControl {
       iser: ISER::new(base_addr),
       icer: ICER::new(base_addr),
@@ -34,15 +34,15 @@ impl EnableControl {
 
 #[derive(Copy, Clone)]
 struct ISER {
-  base_addr: u32,
+  base_addr: *const u32,
 }
 
 impl Register for ISER {
-  fn new(base_addr: u32) -> Self {
+  fn new(base_addr: *const u32) -> Self {
     ISER { base_addr: base_addr }
   }
 
-  fn base_addr(&self) -> u32 {
+  fn base_addr(&self) -> *const u32 {
     self.base_addr
   }
 
@@ -77,15 +77,15 @@ impl ISER {
 
 #[derive(Copy, Clone)]
 struct ICER {
-  base_addr: u32,
+  base_addr: *const u32,
 }
 
 impl Register for ICER {
-  fn new(base_addr: u32) -> Self {
+  fn new(base_addr: *const u32) -> Self {
     ICER { base_addr: base_addr }
   }
 
-  fn base_addr(&self) -> u32 {
+  fn base_addr(&self) -> *const u32 {
     self.base_addr
   }
 

--- a/altos-rust/port/cortex-m0/src/interrupt/mod.rs
+++ b/altos-rust/port/cortex-m0/src/interrupt/mod.rs
@@ -12,7 +12,7 @@ mod priority;
 
 #[derive(Copy, Clone)]
 pub struct NVIC {
-  mem_addr: u32,
+  mem_addr: *const u32,
   enable: enable::EnableControl,
   pending: pending::PendingControl,
   priority: priority::PriorityControl,
@@ -26,7 +26,7 @@ impl Control for NVIC {
 
 impl NVIC {
   pub fn nvic() -> Self {
-    const NVIC_ADDR: u32 = 0xE000E100;
+    const NVIC_ADDR: *const u32 = 0xE000E100 as *const _;
     NVIC {
       mem_addr: NVIC_ADDR,
       enable: enable::EnableControl::new(NVIC_ADDR),
@@ -34,7 +34,7 @@ impl NVIC {
       priority: priority::PriorityControl::new(NVIC_ADDR),
     }
   }
-  
+
   pub fn enable_interrupt(&self, interrupt: u8) {
     self.enable.enable_interrupt(interrupt);
   }

--- a/altos-rust/port/cortex-m0/src/interrupt/pending.rs
+++ b/altos-rust/port/cortex-m0/src/interrupt/pending.rs
@@ -12,7 +12,7 @@ pub struct PendingControl {
 }
 
 impl PendingControl {
-  pub fn new(base_addr: u32) -> Self {
+  pub fn new(base_addr: *const u32) -> Self {
     PendingControl {
       ispr: ISPR::new(base_addr),
       icpr: ICPR::new(base_addr),
@@ -34,15 +34,15 @@ impl PendingControl {
 
 #[derive(Copy, Clone)]
 struct ISPR {
-  base_addr: u32,
+  base_addr: *const u32,
 }
 
 impl Register for ISPR {
-  fn new(base_addr: u32) -> Self {
+  fn new(base_addr: *const u32) -> Self {
     ISPR { base_addr: base_addr }
   }
 
-  fn base_addr(&self) -> u32 {
+  fn base_addr(&self) -> *const u32 {
     self.base_addr
   }
   
@@ -78,15 +78,15 @@ impl ISPR {
 
 #[derive(Copy, Clone)]
 struct ICPR {
-  base_addr: u32,
+  base_addr: *const u32,
 }
 
 impl Register for ICPR {
-  fn new(base_addr: u32) -> Self {
+  fn new(base_addr: *const u32) -> Self {
     ICPR { base_addr: base_addr }
   }
 
-  fn base_addr(&self) -> u32 {
+  fn base_addr(&self) -> *const u32 {
     self.base_addr
   }
 

--- a/altos-rust/port/cortex-m0/src/interrupt/priority.rs
+++ b/altos-rust/port/cortex-m0/src/interrupt/priority.rs
@@ -42,7 +42,7 @@ pub struct PriorityControl {
 }
 
 impl PriorityControl {
-  pub fn new(base_addr: u32) -> Self {
+  pub fn new(base_addr: *const u32) -> Self {
     PriorityControl {
       ipr_registers: [
         IPR::new(base_addr, 0x00),
@@ -77,16 +77,16 @@ impl PriorityControl {
 
 #[derive(Copy, Clone)]
 struct IPR {
-  base_addr: u32,
+  base_addr: *const u32,
   mem_offset: u32,
 }
 
 impl Register for IPR {
-  fn new(_base_addr: u32) -> Self {
+  fn new(_base_addr: *const u32) -> Self {
     unimplemented!();
   }
 
-  fn base_addr(&self) -> u32 {
+  fn base_addr(&self) -> *const u32 {
     self.base_addr
   }
 
@@ -96,7 +96,7 @@ impl Register for IPR {
 }
 
 impl IPR {
-  fn new(base_addr: u32, offset: u32) -> Self {
+  fn new(base_addr: *const u32, offset: u32) -> Self {
     IPR {
       base_addr: base_addr,
       mem_offset: offset,
@@ -107,7 +107,7 @@ impl IPR {
     if interrupt > 3 {
       panic!("IPR::set_priority - IPR register only contains up to 4 interrupt priorities!");
     }
-    
+
     let mask = priority.mask();
     unsafe {
       let mut reg = self.addr();

--- a/altos-rust/port/cortex-m0/src/lib.rs
+++ b/altos-rust/port/cortex-m0/src/lib.rs
@@ -13,6 +13,10 @@
 //#![feature(compiler_builtins_lib)] // Keep this around in case we want to try and get it working
 #![no_std]
 
+#[cfg(test)]
+#[macro_use]
+extern crate std;
+
 extern crate altos_core;
 
 pub extern crate arm;

--- a/altos-rust/port/cortex-m0/src/peripheral/gpio/afr.rs
+++ b/altos-rust/port/cortex-m0/src/peripheral/gpio/afr.rs
@@ -55,7 +55,7 @@ pub struct AlternateFunctionControl {
 }
 
 impl AlternateFunctionControl {
-  pub fn new(base_addr: u32) -> Self {
+  pub fn new(base_addr: *const u32) -> Self {
     AlternateFunctionControl {
       afrl: AFRL::new(base_addr),
       afrh: AFRH::new(base_addr),
@@ -83,15 +83,15 @@ impl AlternateFunctionControl {
 
 #[derive(Copy, Clone)]
 struct AFRL {
-  base_addr: u32,
+  base_addr: *const u32,
 }
 
 impl Register for AFRL {
-  fn new(base_addr: u32) -> Self {
+  fn new(base_addr: *const u32) -> Self {
     AFRL { base_addr: base_addr }
   }
 
-  fn base_addr(&self) -> u32 {
+  fn base_addr(&self) -> *const u32 {
     self.base_addr
   }
 
@@ -106,7 +106,7 @@ impl AFRL {
       panic!("AFRL::set_function - specified port must be between [0..7]!");
     }
     let mask = function.mask();
-    
+
     unsafe {
       let mut reg = self.addr();
 
@@ -119,7 +119,7 @@ impl AFRL {
     if port > 8 {
       panic!("AFRL::get_function - specified port must be between [0..7]!");
     }
-    
+
     let mask = unsafe {
       let reg = self.addr();
 
@@ -131,15 +131,15 @@ impl AFRL {
 
 #[derive(Copy, Clone)]
 struct AFRH {
-  base_addr: u32,
+  base_addr: *const u32,
 }
 
 impl Register for AFRH {
-  fn new(base_addr: u32) -> Self {
+  fn new(base_addr: *const u32) -> Self {
     AFRH { base_addr: base_addr }
   }
 
-  fn base_addr(&self) -> u32 {
+  fn base_addr(&self) -> *const u32 {
     self.base_addr
   }
 
@@ -154,7 +154,7 @@ impl AFRH {
       panic!("AFRL::set_function - specified port must be between [8..15]!");
     }
     let mask = function.mask();
-    
+
     unsafe {
       let mut reg = self.addr();
 
@@ -167,12 +167,29 @@ impl AFRH {
     if port > 15 || port < 8 {
       panic!("AFRL::get_function - specified port must be between [8..15]!");
     }
-    
+
     let mask = unsafe {
       let reg = self.addr();
 
       *reg & (0b1111 << (port * 4) + 8)
     };
     AlternateFunction::from_mask(mask)
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn test_afrh_set_function() {
+    let test_reg: u32 = 0;
+    let base_addr: *const u32 = &test_reg;
+
+    println!("VALUE OF TEST_REG BEFORE: {}", test_reg);
+    let afrh = unsafe { AFRH::new(base_addr.offset(-0x24)) };
+    afrh.set_function(AlternateFunction::One, 9);
+    println!("VALUE OF TEST_REG AFTER: {}", test_reg);
+    assert!(false);
   }
 }

--- a/altos-rust/port/cortex-m0/src/peripheral/gpio/afr.rs
+++ b/altos-rust/port/cortex-m0/src/peripheral/gpio/afr.rs
@@ -151,7 +151,7 @@ impl Register for AFRH {
 impl AFRH {
   fn set_function(&self, function: AlternateFunction, port: u8) {
     if port > 15 || port < 8 {
-      panic!("AFRL::set_function - specified port must be between [8..15]!");
+      panic!("AFRH::set_function - specified port must be between [8..15]!");
     }
     let mask = function.mask();
 
@@ -192,10 +192,40 @@ mod tests {
     let test_reg: u32 = 0;
     let base_addr: *const u32 = &test_reg;
 
-    println!("VALUE OF TEST_REG BEFORE: {}", test_reg);
     let afrh = unsafe { AFRH::new(base_addr.offset(-0x24)) };
-    afrh.set_function(AlternateFunction::One, 9);
-    println!("VALUE OF TEST_REG AFTER: {}", test_reg);
-    assert!(false);
+    afrh.set_function(AlternateFunction::Five, 8);
+
+    assert_eq!(test_reg, 0x5);
+  }
+
+  #[test]
+  #[should_panic]
+  fn test_afrh_set_port_out_of_bounds_panics() {
+    let test_reg: u32 = 0;
+    let base_addr: *const u32 = &test_reg;
+
+    let afrh = unsafe { AFRH::new(base_addr.offset(-0x24)) };
+    afrh.set_function(AlternateFunction::Seven, 2);
+  }
+
+  #[test]
+  fn test_afrl_set_function() {
+    let test_reg: u32 = 0;
+    let base_addr: *const u32 = &test_reg;
+
+    let afrl = unsafe { AFRL::new(base_addr.offset(-0x20)) };
+    afrl.set_function(AlternateFunction::Two, 3);
+
+    assert_eq!(test_reg, 0x2000);
+  }
+
+  #[test]
+  #[should_panic]
+  fn test_afrl_set_port_out_of_bounds_panics() {
+    let test_reg: u32 = 0;
+    let base_addr: *const u32 = &test_reg;
+
+    let afrl = unsafe { AFRL::new(base_addr.offset(-0x20)) };
+    afrl.set_function(AlternateFunction::Two, 10);
   }
 }

--- a/altos-rust/port/cortex-m0/src/peripheral/gpio/bsrr.rs
+++ b/altos-rust/port/cortex-m0/src/peripheral/gpio/bsrr.rs
@@ -7,15 +7,15 @@ use super::super::Register;
 
 #[derive(Copy, Clone)]
 pub struct BSRR {
-  base_addr: u32,
+  base_addr: *const u32,
 }
 
 impl Register for BSRR {
-  fn new(base_addr: u32) -> Self {
+  fn new(base_addr: *const u32) -> Self {
     BSRR { base_addr: base_addr }
   }
 
-  fn base_addr(&self) -> u32 {
+  fn base_addr(&self) -> *const u32 {
     self.base_addr
   }
 

--- a/altos-rust/port/cortex-m0/src/peripheral/gpio/mod.rs
+++ b/altos-rust/port/cortex-m0/src/peripheral/gpio/mod.rs
@@ -33,12 +33,12 @@ pub enum Group {
   F,
 }
 
-/// A GPIO contains the base address for a 
+/// A GPIO contains the base address for a
 /// memory mapped GPIO group associated with
 /// it.
 #[derive(Copy, Clone)]
 pub struct GPIO {
-  mem_addr: u32,
+  mem_addr: *const u32,
   moder: moder::MODER,
   otyper: otyper::OTYPER,
   bsrr: bsrr::BSRR,
@@ -56,15 +56,15 @@ impl Control for GPIO {
 impl GPIO {
   fn group(group: Group) -> GPIO {
     match group {
-      Group::A => GPIO::new(0x4800_0000),
-      Group::B => GPIO::new(0x4800_0400),
-      Group::C => GPIO::new(0x4800_0800),
-      Group::F => GPIO::new(0x4800_1400),
+      Group::A => GPIO::new(0x4800_0000 as *const _),
+      Group::B => GPIO::new(0x4800_0400 as *const _),
+      Group::C => GPIO::new(0x4800_0800 as *const _),
+      Group::F => GPIO::new(0x4800_1400 as *const _),
     }
   }
 
-  fn new(mem_addr: u32) -> GPIO {
-    GPIO { 
+  fn new(mem_addr: *const u32) -> GPIO {
+    GPIO {
       mem_addr: mem_addr,
       moder: moder::MODER::new(mem_addr),
       otyper: otyper::OTYPER::new(mem_addr),
@@ -74,17 +74,17 @@ impl GPIO {
       afr: afr::AlternateFunctionControl::new(mem_addr),
     }
   }
-  
+
   /// Enable a GPIO group, you must do this before you can set any
   /// pins within a group.
-  /// 
+  ///
   /// Example Usage:
   /// ```
   ///   GPIO::enable(Group::B); // Enable IO group B (LED is pb3)
   /// ```
   pub fn enable(group: Group) {
     let rcc = rcc::rcc();
-    
+
     // Get the register bit that should be set to enable this group
     let io_group = match group {
       Group::A => rcc::Peripheral::GPIOA,
@@ -143,4 +143,3 @@ impl GPIO {
     self. afr.get_function(port)
   }
 }
-

--- a/altos-rust/port/cortex-m0/src/peripheral/gpio/moder.rs
+++ b/altos-rust/port/cortex-m0/src/peripheral/gpio/moder.rs
@@ -38,15 +38,15 @@ impl Mode {
 
 #[derive(Copy, Clone)]
 pub struct MODER {
-  base_addr: u32,
+  base_addr: *const u32,
 }
 
 impl Register for MODER {
-  fn new(base_addr: u32) -> Self {
+  fn new(base_addr: *const u32) -> Self {
     MODER { base_addr: base_addr }
   }
 
-  fn base_addr(&self) -> u32 {
+  fn base_addr(&self) -> *const u32 {
     self.base_addr
   }
 

--- a/altos-rust/port/cortex-m0/src/peripheral/gpio/ospeedr.rs
+++ b/altos-rust/port/cortex-m0/src/peripheral/gpio/ospeedr.rs
@@ -35,15 +35,15 @@ impl Speed {
 
 #[derive(Copy, Clone)]
 pub struct OSPEEDR {
-  base_addr: u32,
+  base_addr: *const u32,
 }
 
 impl Register for OSPEEDR {
-  fn new(base_addr: u32) -> Self {
+  fn new(base_addr: *const u32) -> Self {
     OSPEEDR { base_addr: base_addr }
   }
 
-  fn base_addr(&self) -> u32 {
+  fn base_addr(&self) -> *const u32 {
     self.base_addr
   }
 

--- a/altos-rust/port/cortex-m0/src/peripheral/gpio/otyper.rs
+++ b/altos-rust/port/cortex-m0/src/peripheral/gpio/otyper.rs
@@ -32,15 +32,15 @@ impl Type {
 
 #[derive(Copy, Clone)]
 pub struct OTYPER {
-  base_addr: u32,
+  base_addr: *const u32,
 }
 
 impl Register for OTYPER {
-  fn new(base_addr: u32) -> Self {
+  fn new(base_addr: *const u32) -> Self {
     OTYPER { base_addr: base_addr }
   }
 
-  fn base_addr(&self) -> u32 {
+  fn base_addr(&self) -> *const u32 {
     self.base_addr
   }
 

--- a/altos-rust/port/cortex-m0/src/peripheral/gpio/pupdr.rs
+++ b/altos-rust/port/cortex-m0/src/peripheral/gpio/pupdr.rs
@@ -35,15 +35,15 @@ impl Pull {
 
 #[derive(Copy, Clone)]
 pub struct PUPDR {
-  base_addr: u32,
+  base_addr: *const u32,
 }
 
 impl Register for PUPDR {
-  fn new(base_addr: u32) -> Self {
+  fn new(base_addr: *const u32) -> Self {
     PUPDR { base_addr: base_addr }
   }
 
-  fn base_addr(&self) -> u32 {
+  fn base_addr(&self) -> *const u32 {
     self.base_addr
   }
 

--- a/altos-rust/port/cortex-m0/src/peripheral/mod.rs
+++ b/altos-rust/port/cortex-m0/src/peripheral/mod.rs
@@ -17,12 +17,13 @@ pub trait Control {
 }
 
 pub trait Register {
-  fn new(base_addr: u32) -> Self;
+  fn new(base_addr: *const u32) -> Self;
 
-  fn base_addr(&self) -> u32;
+  fn base_addr(&self) -> *const u32;
+  // FIXME: Return isize...????
   fn mem_offset(&self) -> u32;
   unsafe fn addr(&self) -> Volatile<u32> {
-    Volatile::new((self.base_addr() + self.mem_offset()) as *const u32)
+    Volatile::new(self.base_addr().offset(self.mem_offset() as isize))
   }
 }
 

--- a/altos-rust/port/cortex-m0/src/peripheral/rcc/clock_control.rs
+++ b/altos-rust/port/cortex-m0/src/peripheral/rcc/clock_control.rs
@@ -67,7 +67,7 @@ pub struct ClockControl {
 }
 
 impl ClockControl {
-  pub fn new(base_addr: u32) -> Self {
+  pub fn new(base_addr: *const u32) -> Self {
     ClockControl {
       cr: CR::new(base_addr),
       cr2: CR2::new(base_addr),
@@ -111,15 +111,15 @@ impl ClockControl {
 /// argument to any of the methods that take a clock argument the kernel will panic.
 #[derive(Copy, Clone)]
 pub struct CR {
-  base_addr: u32,
+  base_addr: *const u32,
 }
 
 impl Register for CR {
-  fn new(base_addr: u32) -> Self {
+  fn new(base_addr: *const u32) -> Self {
     CR { base_addr: base_addr }
   }
 
-  fn base_addr(&self) -> u32 {
+  fn base_addr(&self) -> *const u32 {
     self.base_addr
   }
 
@@ -188,15 +188,15 @@ impl CR {
 /// argument to any of the methods that take a clock argument the kernel will panic.
 #[derive(Copy, Clone)]
 pub struct CR2 {
-  base_addr: u32,
+  base_addr: *const u32,
 }
 
 impl Register for CR2 {
-  fn new(base_addr: u32) -> Self {
+  fn new(base_addr: *const u32) -> Self {
     CR2 { base_addr: base_addr }
   }
 
-  fn base_addr(&self) -> u32 {
+  fn base_addr(&self) -> *const u32 {
     self.base_addr
   }
 

--- a/altos-rust/port/cortex-m0/src/peripheral/rcc/config.rs
+++ b/altos-rust/port/cortex-m0/src/peripheral/rcc/config.rs
@@ -15,7 +15,7 @@ pub struct ConfigControl {
 }
 
 impl ConfigControl {
-  pub fn new(base_addr: u32) -> Self {
+  pub fn new(base_addr: *const u32) -> Self {
     ConfigControl {
       cfgr: CFGR::new(base_addr),
       cfgr2: CFGR2::new(base_addr),
@@ -70,15 +70,15 @@ impl ConfigControl {
 /// Clock Configuration Register
 #[derive(Copy, Clone)]
 struct CFGR {
-  base_addr: u32,
+  base_addr: *const u32,
 }
 
 impl Register for CFGR {
-  fn new(base_addr: u32) -> Self {
+  fn new(base_addr: *const u32) -> Self {
     CFGR { base_addr: base_addr }
   }
 
-  fn base_addr(&self) -> u32 {
+  fn base_addr(&self) -> *const u32 {
     self.base_addr
   }
 
@@ -185,15 +185,15 @@ impl CFGR {
 
 #[derive(Copy, Clone)]
 struct CFGR2 {
-  base_addr: u32,
+  base_addr: *const u32,
 }
 
 impl Register for CFGR2 {
-  fn new(base_addr: u32) -> Self {
+  fn new(base_addr: *const u32) -> Self {
     CFGR2 { base_addr: base_addr }
   }
 
-  fn base_addr(&self) -> u32 {
+  fn base_addr(&self) -> *const u32 {
     self.base_addr
   }
 

--- a/altos-rust/port/cortex-m0/src/peripheral/rcc/enable.rs
+++ b/altos-rust/port/cortex-m0/src/peripheral/rcc/enable.rs
@@ -119,7 +119,7 @@ pub struct PeripheralControl {
 }
 
 impl PeripheralControl {
-  pub fn new(base_addr: u32) -> Self {
+  pub fn new(base_addr: *const u32) -> Self {
     PeripheralControl {
       ahbenr: AHBENR::new(base_addr),
       apbenr1: APBENR1::new(base_addr),
@@ -170,15 +170,15 @@ impl PeripheralControl {
 
 #[derive(Copy, Clone)]
 struct AHBENR {
-  base_addr: u32,
+  base_addr: *const u32,
 }
 
 impl Register for AHBENR {
-  fn new(base_addr: u32) -> Self {
+  fn new(base_addr: *const u32) -> Self {
     AHBENR { base_addr: base_addr }
   }
 
-  fn base_addr(&self) -> u32 {
+  fn base_addr(&self) -> *const u32 {
     self.base_addr
   }
 
@@ -231,15 +231,15 @@ impl AHBENR {
 
 #[derive(Copy, Clone)]
 struct APBENR1 {
-  base_addr: u32,
+  base_addr: *const u32,
 }
 
 impl Register for APBENR1 {
-  fn new(base_addr: u32) -> Self {
+  fn new(base_addr: *const u32) -> Self {
     APBENR1 { base_addr: base_addr }
   }
 
-  fn base_addr(&self) -> u32 {
+  fn base_addr(&self) -> *const u32 {
     self.base_addr
   }
 
@@ -294,15 +294,15 @@ impl APBENR1 {
 
 #[derive(Copy, Clone)]
 struct APBENR2 {
-  base_addr: u32,
+  base_addr: *const u32,
 }
 
 impl Register for APBENR2 {
-  fn new(base_addr: u32) -> Self {
+  fn new(base_addr: *const u32) -> Self {
     APBENR2 { base_addr: base_addr }
   }
 
-  fn base_addr(&self) -> u32 {
+  fn base_addr(&self) -> *const u32 {
     self.base_addr
   }
 

--- a/altos-rust/port/cortex-m0/src/peripheral/rcc/mod.rs
+++ b/altos-rust/port/cortex-m0/src/peripheral/rcc/mod.rs
@@ -23,7 +23,7 @@ pub fn rcc() -> RCC {
 /// Reset and Clock Controller
 #[derive(Copy, Clone)]
 pub struct RCC {
-  mem_addr: u32,
+  mem_addr: *const u32,
   cr: clock_control::ClockControl,
   cfgr: config::ConfigControl,
   enr: enable::PeripheralControl,
@@ -31,13 +31,13 @@ pub struct RCC {
 
 impl Control for RCC {
   unsafe fn mem_addr(&self) -> Volatile<u32> {
-    Volatile::new(self.mem_addr as *const u32)
+    Volatile::new(self.mem_addr)
   }
 }
 
 impl RCC {
   fn rcc() -> Self {
-    const RCC_ADDR: u32 = 0x4002_1000;
+    const RCC_ADDR: *const u32 = 0x4002_1000 as *const _;
     RCC {
       mem_addr: RCC_ADDR,
       cr: clock_control::ClockControl::new(RCC_ADDR),

--- a/altos-rust/port/cortex-m0/src/peripheral/systick/control_status.rs
+++ b/altos-rust/port/cortex-m0/src/peripheral/systick/control_status.rs
@@ -13,15 +13,15 @@ pub enum ClockSource {
 /// The control and status register for the SysTick timer
 #[derive(Copy, Clone)]
 pub struct CSR {
-  base_addr: u32,
+  base_addr: *const u32,
 }
 
 impl Register for CSR {
-  fn new(base_addr: u32) -> Self {
+  fn new(base_addr: *const u32) -> Self {
     CSR { base_addr: base_addr }
   }
 
-  fn base_addr(&self) -> u32 {
+  fn base_addr(&self) -> *const u32 {
     self.base_addr
   }
 

--- a/altos-rust/port/cortex-m0/src/peripheral/systick/current_value.rs
+++ b/altos-rust/port/cortex-m0/src/peripheral/systick/current_value.rs
@@ -7,15 +7,15 @@ use super::super::Register;
 
 #[derive(Copy, Clone)]
 pub struct CVR {
-  base_addr: u32,
+  base_addr: *const u32,
 }
 
 impl Register for CVR {
-  fn new(base_addr: u32) -> Self {
+  fn new(base_addr: *const u32) -> Self {
     CVR { base_addr: base_addr }
   }
 
-  fn base_addr(&self) -> u32 {
+  fn base_addr(&self) -> *const u32 {
     self.base_addr
   }
 

--- a/altos-rust/port/cortex-m0/src/peripheral/systick/mod.rs
+++ b/altos-rust/port/cortex-m0/src/peripheral/systick/mod.rs
@@ -16,7 +16,7 @@ pub fn systick() -> SysTick {
 
 #[derive(Copy, Clone)]
 pub struct SysTick {
-  mem_addr: u32,
+  mem_addr: *const u32,
   csr: control_status::CSR,
   rvr: reload_value::RVR,
   cvr: current_value::CVR,
@@ -24,13 +24,13 @@ pub struct SysTick {
 
 impl Control for SysTick {
   unsafe fn mem_addr(&self) -> Volatile<u32> {
-    Volatile::new(self.mem_addr as *const u32)
+    Volatile::new(self.mem_addr)
   }
 }
 
 impl SysTick {
   fn systick() -> Self {
-    const SYSTICK_ADDR: u32 = 0xE000E010;
+    const SYSTICK_ADDR: *const u32 = 0xE000E010 as *const _;
     SysTick {
       mem_addr: SYSTICK_ADDR,
       csr: control_status::CSR::new(SYSTICK_ADDR),

--- a/altos-rust/port/cortex-m0/src/peripheral/systick/reload_value.rs
+++ b/altos-rust/port/cortex-m0/src/peripheral/systick/reload_value.rs
@@ -9,15 +9,15 @@ use super::super::Register;
 /// Register)
 #[derive(Copy, Clone)]
 pub struct RVR {
-  base_addr: u32,
+  base_addr: *const u32,
 }
 
 impl Register for RVR {
-  fn new(base_addr: u32) -> Self {
+  fn new(base_addr: *const u32) -> Self {
     RVR { base_addr: base_addr }
   }
 
-  fn base_addr(&self) -> u32 {
+  fn base_addr(&self) -> *const u32 {
     self.base_addr
   }
 

--- a/altos-rust/port/cortex-m0/src/system_control/icsr.rs
+++ b/altos-rust/port/cortex-m0/src/system_control/icsr.rs
@@ -7,15 +7,15 @@ use ::peripheral::Register;
 
 #[derive(Copy, Clone)]
 pub struct ICSR {
-  base_addr: u32,
+  base_addr: *const u32,
 }
 
 impl Register for ICSR {
-  fn new(base_addr: u32) -> Self {
+  fn new(base_addr: *const u32) -> Self {
     ICSR { base_addr: base_addr }
   }
 
-  fn base_addr(&self) -> u32 {
+  fn base_addr(&self) -> *const u32 {
     self.base_addr
   }
 

--- a/altos-rust/port/cortex-m0/src/system_control/mod.rs
+++ b/altos-rust/port/cortex-m0/src/system_control/mod.rs
@@ -15,19 +15,19 @@ pub fn scb() -> SCB {
 /// System Control Block
 #[derive(Copy, Clone)]
 pub struct SCB {
-  mem_addr: u32,
+  mem_addr: *const u32,
   icsr: icsr::ICSR,
 }
 
 impl Control for SCB {
   unsafe fn mem_addr(&self) -> Volatile<u32> {
-    Volatile::new(self.mem_addr as *const u32)
+    Volatile::new(self.mem_addr)
   }
 }
 
 impl SCB {
   fn scb() -> Self {
-    const SCB_ADDR: u32 = 0xE000_ED00;
+    const SCB_ADDR: *const u32 = 0xE000_ED00 as *const _;
     SCB {
       mem_addr: SCB_ADDR,
       icsr: icsr::ICSR::new(SCB_ADDR),

--- a/altos-rust/port/cortex-m0/src/time.rs
+++ b/altos-rust/port/cortex-m0/src/time.rs
@@ -40,21 +40,6 @@ pub fn delay_s(s: usize) {
 /// This should only be called once upon initialization of the system. Setting this after the
 /// system has been running for a while could cause some tasks that are delayed to wake up too
 /// early.
-///
-/// # Example
-///
-/// ```rust,no_run
-/// use altos_core::time::{self, Time};
-///
-/// // Assuming we tick 2 times every ms...
-/// time::set_resolution(2);
-/// // now every other tick we will increment the system timer by 1 ms
-///
-/// time::tick();
-/// time::tick();
-///
-/// assert_eq!(Time::now().msec, 1);
-/// ```
 pub fn set_resolution(new: usize) {
   MS_RESOLUTION.store(new, Ordering::Relaxed);
 }

--- a/altos-rust/src/lib.rs
+++ b/altos-rust/src/lib.rs
@@ -10,8 +10,66 @@
 extern crate cortex_m0;
 
 use cortex_m0::arm;
+use cortex_m0::kernel;
+use cortex_m0::time;
+use cortex_m0::kernel::task::Priority;
+use cortex_m0::kernel::task::args::Args;
+use cortex_m0::kernel::sync::Mutex;
+use cortex_m0::peripheral::gpio::{self, Port};
+
+// Since we can't statically create a port object (maybe we should be able to?) we make it an
+// option then initialize it down in `application_entry`
+static LED: Mutex<Option<Port>> = Mutex::new(None);
 
 #[no_mangle]
 pub fn application_entry() -> ! {
+  // Initialize the LED lock
+  {
+    let mut led = LED.lock();
+    *led = Some(Port::new(3, gpio::Group::B));
+  }
+
+  kernel::syscall::new_task(blink_1, Args::empty(), 512, Priority::Normal, "blink_1");
+  kernel::syscall::new_task(blink_2, Args::empty(), 512, Priority::Normal, "blink_1");
+  kernel::task::start_scheduler();
+
   loop { unsafe { arm::asm::bkpt() }; }
+}
+
+fn blink_1(_args: &mut Args) {
+  loop {
+    // Grab the LED lock
+    let guard = LED.lock();
+    {
+      // Get a reference to the underlying port
+      let led = guard.as_ref().unwrap();
+      // Blink 10 times at 100 ms intervals
+      for _ in 0..10 {
+        led.set();
+        time::delay_ms(100);
+        led.reset();
+        time::delay_ms(100);
+      }
+    }
+    // Release the lock before yielding our time slice
+    drop(guard);
+    kernel::syscall::sched_yield();
+  }
+}
+
+fn blink_2(_args: &mut Args) {
+  loop {
+    let guard = LED.lock();
+    {
+      let led = guard.as_ref().unwrap();
+      for _ in 0..5 {
+        led.set();
+        time::delay_ms(500);
+        led.reset();
+        time::delay_ms(500);
+      }
+    }
+    drop(guard);
+    kernel::syscall::sched_yield();
+  }
 }

--- a/altos-rust/src/lib.rs
+++ b/altos-rust/src/lib.rs
@@ -30,7 +30,8 @@ pub fn application_entry() -> ! {
   }
 
   kernel::syscall::new_task(blink_1, Args::empty(), 512, Priority::Normal, "blink_1");
-  kernel::syscall::new_task(blink_2, Args::empty(), 512, Priority::Normal, "blink_1");
+  kernel::syscall::new_task(blink_2, Args::empty(), 512, Priority::Normal, "blink_2");
+  kernel::syscall::new_task(blink_sleep, Args::empty(), 512, Priority::Normal, "blink_3");
   kernel::task::start_scheduler();
 
   loop { unsafe { arm::asm::bkpt() }; }
@@ -68,6 +69,19 @@ fn blink_2(_args: &mut Args) {
         led.reset();
         time::delay_ms(500);
       }
+    }
+    drop(guard);
+    kernel::syscall::sched_yield();
+  }
+}
+
+fn blink_sleep(_args: &mut Args) {
+  loop {
+    let guard = LED.lock();
+    {
+      let led = guard.as_ref().unwrap();
+      led.reset();
+      time::delay_ms(2000);
     }
     drop(guard);
     kernel::syscall::sched_yield();


### PR DESCRIPTION
This gets tests working for the portability layer. In order to make the tests work, the base address need to be stored as an actual pointer type. This is because when compiling for testing, if the test machine is 64 bit it will use 64 bit addresses (clearly...) so using a u32 as an address as we were before would truncate the address. Because of this the trait interface had to change as well to use pointer types. This means any future trait implementations should also change their types.

@pdouglas94 