### PR TITLE
Fix xargo breaking tests, add test framework for Port

### DIFF
--- a/altos-rust/Makefile
+++ b/altos-rust/Makefile
@@ -79,12 +79,12 @@ gdb-ocd: debug
 	@$(gdb) $(ocd_gdb_flags) $(debug_build)
 
 test:
-	@$(cargo) test $(test_args)
+	@cargo test $(test_args)
 	@#FIXME: when running with the spec flag we don't seem to build with the 'test'
 	@#	feature flag enabled for our core build, so we need to compile and run the
 	@#	tests for the port layer seperately... I think? I'm not sure, this requires
 	@#	more research but doing this works for now.
-	@$(cargo) test --manifest-path $(path_to_cm0)Cargo.toml
+	@cargo test --manifest-path $(path_to_cm0)Cargo.toml
 	@rm -rf $(path_to_cm0)target $(path_to_cm0)Cargo.lock
 
 test_verbose:

--- a/altos-rust/port/cortex-m0/src/exceptions/mod.rs
+++ b/altos-rust/port/cortex-m0/src/exceptions/mod.rs
@@ -73,8 +73,8 @@ extern "C" fn systick_handler() {
 /// interrupts are serviced first
 #[naked]
 extern "C" fn pend_sv_handler() {
+  #[cfg(target_arch="arm")]
   unsafe {
-    #[cfg(target_arch="arm")]
     asm!(
       concat!(
         "cpsid i\n", /* disable interrupts for context switch */

--- a/altos-rust/port/cortex-m0/src/lib.rs
+++ b/altos-rust/port/cortex-m0/src/lib.rs
@@ -22,6 +22,9 @@ extern crate altos_core;
 pub extern crate arm;
 //pub extern crate compiler_builtins; // See above comment
 
+#[cfg(test)]
+mod test;
+
 mod exceptions;
 pub mod peripheral;
 pub mod time;
@@ -46,7 +49,7 @@ pub mod kernel {
     pub use altos_core::{start_scheduler};
     pub use altos_core::{Priority};
   }
-  
+
   // TODO: Do we want to expose an allocation interface?
   pub mod alloc {
     pub use altos_core::alloc::boxed::Box;
@@ -68,7 +71,7 @@ pub mod kernel {
 #[cfg(not(test))]
 #[lang = "eh_personality"] extern "C" fn eh_personality() {}
 #[cfg(not(test))]
-#[lang = "panic_fmt"] 
+#[lang = "panic_fmt"]
 extern "C" fn panic_fmt(_fmt: core::fmt::Arguments, _file: &'static str, _line: usize) -> ! {
   loop {
     unsafe {
@@ -113,10 +116,10 @@ fn init_data_segment() {
         "adds r2, #4\n",
         "b copy\n", /* repeat until done */
       "d_done:\n")
-    : /* no outputs */ 
-    : /* no inputs */ 
+    : /* no outputs */
+    : /* no inputs */
     : "r0", "r1", "r2", "r3" /* clobbers */
-    : "volatile");  
+    : "volatile");
   }
 }
 
@@ -193,7 +196,7 @@ fn init_clock() {
   while !rcc.clock_is_ready(rcc::Clock::PLL) {}
   // Switch over to the PLL for running the system
   rcc.set_system_clock_source(rcc::Clock::PLL);
-  
+
   // Our system clock sets itself to interrupt every 1 ms
   time::set_resolution(1);
 }

--- a/altos-rust/port/cortex-m0/src/peripheral/gpio/afr.rs
+++ b/altos-rust/port/cortex-m0/src/peripheral/gpio/afr.rs
@@ -186,46 +186,35 @@ impl AFRH {
 #[cfg(test)]
 mod tests {
   use super::*;
+  use test;
 
   #[test]
   fn test_afrh_set_function() {
-    let test_reg: u32 = 0;
-    let base_addr: *const u32 = &test_reg;
-
-    let afrh = unsafe { AFRH::new(base_addr.offset(-0x24)) };
+    let afrh = test::create_register::<AFRH>(0x24);
     afrh.set_function(AlternateFunction::Five, 8);
 
-    assert_eq!(test_reg, 0x5);
+    assert_eq!(afrh.register_value(), 0x5);
   }
 
   #[test]
   #[should_panic]
   fn test_afrh_set_port_out_of_bounds_panics() {
-    let test_reg: u32 = 0;
-    let base_addr: *const u32 = &test_reg;
-
-    let afrh = unsafe { AFRH::new(base_addr.offset(-0x24)) };
+    let afrh = test::create_register::<AFRH>(0x24);
     afrh.set_function(AlternateFunction::Seven, 2);
   }
 
   #[test]
   fn test_afrl_set_function() {
-    let test_reg: u32 = 0;
-    let base_addr: *const u32 = &test_reg;
-
-    let afrl = unsafe { AFRL::new(base_addr.offset(-0x20)) };
+    let afrl = test::create_register::<AFRL>(0x20);
     afrl.set_function(AlternateFunction::Two, 3);
 
-    assert_eq!(test_reg, 0x2000);
+    assert_eq!(afrl.register_value(), 0x2000);
   }
 
   #[test]
   #[should_panic]
   fn test_afrl_set_port_out_of_bounds_panics() {
-    let test_reg: u32 = 0;
-    let base_addr: *const u32 = &test_reg;
-
-    let afrl = unsafe { AFRL::new(base_addr.offset(-0x20)) };
+    let afrl = test::create_register::<AFRL>(0x20);
     afrl.set_function(AlternateFunction::Two, 10);
   }
 }

--- a/altos-rust/port/cortex-m0/src/test.rs
+++ b/altos-rust/port/cortex-m0/src/test.rs
@@ -1,0 +1,52 @@
+// test.rs
+// AltOSRust
+//
+// Created by Daniel Seitz on 1/27/17
+
+use peripheral::{Register};
+use std::ops::{Deref, DerefMut};
+use std::boxed::Box;
+
+pub struct MockRegister<T: Register> {
+  addr: *mut u32,
+  register: T,
+}
+
+impl<T: Register> MockRegister<T> {
+  fn new(offset: u32) -> Self {
+    let temp_reg = Box::new(0);
+    let ptr = Box::into_raw(temp_reg);
+    MockRegister {
+      addr: ptr,
+      register: unsafe { T::new(ptr.offset(-((offset as isize)/4))) },
+    }
+  }
+
+  pub fn register_value(&self) -> u32 {
+    unsafe { *self.addr }
+  }
+}
+
+impl<T: Register> Deref for MockRegister<T> {
+  type Target = T;
+  fn deref(&self) -> &Self::Target {
+    &self.register
+  }
+}
+
+impl<T: Register> DerefMut for MockRegister<T> {
+  fn deref_mut(&mut self) -> &mut Self::Target {
+    &mut self.register
+  }
+}
+
+impl<T: Register> Drop for MockRegister<T> {
+  fn drop(&mut self) {
+    unsafe { drop(Box::from_raw(self.addr)) };
+  }
+}
+
+pub fn create_register<T: Register>(offset: u32) -> MockRegister<T> {
+  MockRegister::new(offset)
+}
+


### PR DESCRIPTION
The newer versions of xargo were breaking the tests being run, so we
switched over to just using `cargo` for testing. Potentially we can
switch over to cargo for cross compiling now that our target is
supported, but we'll need to do a little research to see how that works.

The testing framework should make it much easier to test out registers,
any additional functionality that may be needed can be added fairly
easily from the test module as well.

@RJ-Russell 