### PR TITLE
Update test framework for port layer

### DIFF
--- a/altos-rust/Cargo.lock
+++ b/altos-rust/Cargo.lock
@@ -1,9 +1,6 @@
 [root]
-name = "altos_rust"
+name = "volatile"
 version = "0.1.0"
-dependencies = [
- "cortex_m0 0.1.0",
-]
 
 [[package]]
 name = "altos_core"
@@ -12,6 +9,13 @@ dependencies = [
  "bump_allocator 0.1.0",
  "cm0_atomic 0.1.0",
  "volatile 0.1.0",
+]
+
+[[package]]
+name = "altos_rust"
+version = "0.1.0"
+dependencies = [
+ "cortex_m0 0.1.0",
 ]
 
 [[package]]
@@ -36,8 +40,4 @@ dependencies = [
  "altos_core 0.1.0",
  "arm 0.1.0",
 ]
-
-[[package]]
-name = "volatile"
-version = "0.1.0"
 

--- a/altos-rust/Cargo.toml
+++ b/altos-rust/Cargo.toml
@@ -33,3 +33,5 @@ lto = false
 debug-assertions = true
 codegen-units = 1
 panic = "unwind"
+
+[workspace]

--- a/altos-rust/Makefile
+++ b/altos-rust/Makefile
@@ -25,9 +25,9 @@ test_dependencies = altos_core \
 										arm \
 										volatile \
 										cm0_atomic \
-										#cortex_m0 \
+										cortex_m0 \
 
-# --lib flag only runs the unit test suite, doc tests are currently and issue for cross-compiled
+# --lib flag only runs the unit test suite, doc tests are currently an issue for cross-compiled
 #  platforms. See: https://github.com/rust-lang/cargo/issues/1789
 test_args = $(foreach dep, $(test_dependencies),-p $(dep)) --lib
 
@@ -80,12 +80,6 @@ gdb-ocd: debug
 
 test:
 	@cargo test $(test_args)
-	@#FIXME: when running with the spec flag we don't seem to build with the 'test'
-	@#	feature flag enabled for our core build, so we need to compile and run the
-	@#	tests for the port layer seperately... I think? I'm not sure, this requires
-	@#	more research but doing this works for now.
-	@cargo test --manifest-path $(path_to_cm0)Cargo.toml
-	@rm -rf $(path_to_cm0)target $(path_to_cm0)Cargo.lock
 
 test_verbose:
 	@$(cargo) test $(test_args) -- --nocapture

--- a/altos-rust/Xargo.toml
+++ b/altos-rust/Xargo.toml
@@ -1,3 +1,5 @@
 
 [target.thumbv6m-none-eabi.dependencies]
 collections = {}
+
+[workspace]

--- a/altos-rust/altos-core/src/task/control.rs
+++ b/altos-rust/altos-core/src/task/control.rs
@@ -19,7 +19,7 @@ mod tid {
   use atomic::{ATOMIC_USIZE_INIT, AtomicUsize, Ordering};
 
   static CURRENT_TID: AtomicUsize = ATOMIC_USIZE_INIT;
-  
+
   /// Atomically increment the task id and return the old value
   pub fn fetch_next_tid() -> usize {
     CURRENT_TID.fetch_add(1, Ordering::Relaxed)
@@ -90,7 +90,7 @@ pub enum State {
 
   /// The task is ready to be run if the scheduler decides to pick it.
   Ready,
-  
+
   /// The task is currently running.
   Running,
 
@@ -103,7 +103,7 @@ pub enum State {
 }
 
 /// A `TaskControl` tracks the running state of a task.
-/// 
+///
 /// This struct keeps track of information about a specific task. When a `TaskControl` goes out of
 /// scope the memory associated with it is freed.
 #[repr(C)]
@@ -184,10 +184,10 @@ impl TaskControl {
 }
 
 /// A `TaskHandle` references a `TaskControl` and provides access to some state about it.
-/// 
+///
 /// A `TaskHandle` is created whenever a new task is requested from the operating system. It
 /// provides a way to examine the state of the task at run time as well as perform some operations
-/// on it like marking it for destruction. 
+/// on it like marking it for destruction.
 ///
 /// This struct is thread safe, as all accesses to the internal `TaskControl` are checked for
 /// validity. If a task has been destroyed by one thread, then any other thread trying to access it
@@ -239,8 +239,8 @@ impl TaskHandle {
     //    A possible solution... allocate a heap space for each task. Pass a heap allocation
     //    interface to the task implicitly and do all dynamic memory allocation through this
     //    interface. When the task is destroyed we can just free the whole task-specific heap so we
-    //    wont have to worry about leaking memory. This means we would likely have to disallow core 
-    //    library `Box` allocations within the task. Or... we just don't allow dynamic allocation 
+    //    wont have to worry about leaking memory. This means we would likely have to disallow core
+    //    library `Box` allocations within the task. Or... we just don't allow dynamic allocation
     //    within tasks. - Daniel Seitz
     let _g = CriticalSection::begin();
     if self.is_valid() {
@@ -373,7 +373,7 @@ impl TaskHandle {
   /// # use altos_core::args::Args;
   ///
   /// let handle = new_task(test_task, Args::empty(), 512, Priority::Normal, "new_task_name");
-  /// 
+  ///
   /// match handle.name() {
   ///   Ok(name) => { /* Task was valid */ },
   ///   Err(()) => { /* Task was destroyed */ },
@@ -434,21 +434,21 @@ impl TaskHandle {
   }
 
   /// Check if the task pointed to by this handle is valid
-  /// 
+  ///
   /// # Examples
-  /// 
+  ///
   /// ```rust,no_run
   /// use altos_core::syscall::new_task;
-  /// 
+  ///
   /// let handle = new_task(test_task, Args::empty(), 512, Priority::Normal, "new_task_name");
-  /// 
+  ///
   /// if handle.is_valid() {
   ///   // The task is still valid
   /// }
   /// else {
   ///   // The task has been destroyed
   /// }
-  /// 
+  ///
   /// ```
   pub fn is_valid(&self) -> bool {
     // UNSAFE: Yes, potentially we're reading from a dangling pointer (if the task has been freed,
@@ -478,7 +478,7 @@ impl TaskHandle {
 mod tests {
   use super::*;
   use test;
-  
+
   fn get_task() -> TaskControl {
     // NOTE: We can't return the TaskControl and the TaskHandle as a tuple here because the
     // TaskControl object get's moved on return so we would end up with a dangling pointer in our

--- a/altos-rust/port/cortex-m0/src/peripheral/gpio/afr.rs
+++ b/altos-rust/port/cortex-m0/src/peripheral/gpio/afr.rs
@@ -190,7 +190,7 @@ mod tests {
 
   #[test]
   fn test_afrh_set_function() {
-    let afrh = test::create_register::<AFRH>(0x24);
+    let afrh = test::create_register::<AFRH>();
     afrh.set_function(AlternateFunction::Five, 8);
 
     assert_eq!(afrh.register_value(), 0x5);
@@ -199,13 +199,13 @@ mod tests {
   #[test]
   #[should_panic]
   fn test_afrh_set_port_out_of_bounds_panics() {
-    let afrh = test::create_register::<AFRH>(0x24);
+    let afrh = test::create_register::<AFRH>();
     afrh.set_function(AlternateFunction::Seven, 2);
   }
 
   #[test]
   fn test_afrl_set_function() {
-    let afrl = test::create_register::<AFRL>(0x20);
+    let afrl = test::create_register::<AFRL>();
     afrl.set_function(AlternateFunction::Two, 3);
 
     assert_eq!(afrl.register_value(), 0x2000);
@@ -214,7 +214,7 @@ mod tests {
   #[test]
   #[should_panic]
   fn test_afrl_set_port_out_of_bounds_panics() {
-    let afrl = test::create_register::<AFRL>(0x20);
+    let afrl = test::create_register::<AFRL>();
     afrl.set_function(AlternateFunction::Two, 10);
   }
 }

--- a/altos-rust/port/cortex-m0/src/peripheral/gpio/port.rs
+++ b/altos-rust/port/cortex-m0/src/peripheral/gpio/port.rs
@@ -24,8 +24,7 @@ pub struct Port {
 impl Port {
   /// Create a new port for the associated group. Ports are NOT thread safe, if you
   /// must ensure an atomic set of operations on a port use some kind of synchronization
-  /// tool 
-  // TODO: Create synchronization tool...
+  /// tool
   pub fn new(port: u8, group: Group) -> Port {
     if port > 15 {
       //TODO: Handle this more gracefully hopefully

--- a/altos-rust/port/cortex-m0/src/test.rs
+++ b/altos-rust/port/cortex-m0/src/test.rs
@@ -13,12 +13,13 @@ pub struct MockRegister<T: Register> {
 }
 
 impl<T: Register> MockRegister<T> {
-  fn new(offset: u32) -> Self {
+  fn new() -> Self {
     let temp_reg = Box::new(0);
     let ptr = Box::into_raw(temp_reg);
+    let offset = T::new(0x0 as *const _).mem_offset() as isize;
     MockRegister {
       addr: ptr,
-      register: unsafe { T::new(ptr.offset(-((offset as isize)/4))) },
+      register: unsafe { T::new(ptr.offset(-offset/4)) },
     }
   }
 
@@ -46,7 +47,7 @@ impl<T: Register> Drop for MockRegister<T> {
   }
 }
 
-pub fn create_register<T: Register>(offset: u32) -> MockRegister<T> {
-  MockRegister::new(offset)
+pub fn create_register<T: Register>() -> MockRegister<T> {
+  MockRegister::new()
 }
 


### PR DESCRIPTION
Since the register exports its offset as part of its trait, we can just
use that from within the test framework instead of passing in the
offset. This should make for a simpler interface with less chance for
user error.

Also got workspaces working, so we don't have to do the workaround of
compiling the `cortex_m0` crate seperately for tests. This should make
for faster iteration times when writing tests as we won't have to
recompile dependencies.

@RJ-Russell 