### PR TITLE
Interrupt handler for transmissions working

### DIFF
--- a/altos-rust/altos-core/src/queue/mod.rs
+++ b/altos-rust/altos-core/src/queue/mod.rs
@@ -8,10 +8,12 @@
 mod queue;
 mod atomic_queue;
 mod sorted_list;
+mod ringbuffer;
 
 pub use self::queue::*;
 pub use self::atomic_queue::*;
 pub use self::sorted_list::*;
+pub use self::ringbuffer::*;
 
 use alloc::boxed::Box;
 use core::ops::{Deref, DerefMut};

--- a/altos-rust/altos-core/src/queue/ringbuffer.rs
+++ b/altos-rust/altos-core/src/queue/ringbuffer.rs
@@ -1,0 +1,128 @@
+// queue/ringbuffer.rs
+// AltOS Rust
+//
+// Created by Daniel Seitz on 2/5/17
+
+// TODO: Make variable sized ring buffers?
+/// The size of any ring buffers
+pub const RING_BUFFER_SIZE: usize = 8;
+
+/// A ring buffer to keep track of some data
+pub struct RingBuffer {
+  data: [u8; RING_BUFFER_SIZE],
+  // TODO: u8?
+  start: usize,
+  end: usize,
+  full: bool,
+}
+
+impl RingBuffer {
+  /// Create a new RingBuffer that is empty
+  pub const fn new() -> Self {
+    //debug_assert!(size > 0);
+    RingBuffer {
+      data: [0; RING_BUFFER_SIZE],
+      start: 0,
+      end: 0,
+      full: false,
+    }
+  }
+
+  /// Insert a byte into the buffer
+  ///
+  /// Return true if the byte was successfully inserted into the buffer
+  pub fn insert(&mut self, byte: u8) -> bool {
+    if !self.full {
+      self.data[self.end] = byte;
+      self.end += 1;
+      if self.end >= self.data.len() {
+        self.end = 0;
+      }
+      if self.end == self.start {
+        self.full = true;
+      }
+      true
+    }
+    else {
+      false
+    }
+  }
+
+  /// Remove a byte from the buffer if there is one available
+  pub fn remove(&mut self) -> Option<u8> {
+    if self.start != self.end || self.full {
+      let byte = self.data[self.start];
+      self.start += 1;
+      if self.start >= self.data.len() {
+        self.start = 0;
+      }
+      self.full = false;
+      Some(byte)
+    }
+    else {
+      None
+    }
+  }
+
+  /// Check if the buffer is empty
+  pub fn is_empty(&self) -> bool {
+    self.start == self.end && !self.full
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn test_ring_buffer_insert() {
+    let mut buffer = RingBuffer::new();
+
+    buffer.insert(0);
+    buffer.insert(1);
+    buffer.insert(2);
+
+    assert_eq!(buffer.data[0], 0);
+    assert_eq!(buffer.data[1], 1);
+    assert_eq!(buffer.data[2], 2);
+  }
+
+  #[test]
+  fn test_ring_buffer_remove() {
+    let mut buffer = RingBuffer::new();
+
+    assert_eq!(buffer.remove(), None);
+
+    buffer.insert(0);
+    buffer.insert(1);
+
+    assert_eq!(buffer.remove(), Some(0));
+    assert_eq!(buffer.remove(), Some(1));
+    assert_eq!(buffer.remove(), None);
+  }
+
+  #[test]
+  fn test_ring_buffer_overflow_drops_insertion_byte() {
+    let mut buffer = RingBuffer::new();
+
+    for i in 0..RING_BUFFER_SIZE {
+      buffer.insert(i as u8);
+    }
+
+    // Overflow the buffer
+    buffer.insert(!0);
+    // First item should still be 0, not !0
+    assert_eq!(buffer.data[0], 0);
+  }
+
+  #[test]
+  fn test_ring_buffer_is_empty() {
+    let mut buffer = RingBuffer::new();
+
+    assert!(buffer.is_empty());
+
+    buffer.insert(0);
+
+    assert!(!buffer.is_empty());
+  }
+}

--- a/altos-rust/port/cortex-m0/src/interrupt/enable.rs
+++ b/altos-rust/port/cortex-m0/src/interrupt/enable.rs
@@ -19,6 +19,7 @@ impl EnableControl {
     }
   }
 
+  // TODO: Come back and replace the interrupt argument with an enum
   pub fn enable_interrupt(&self, interrupt: u8) {
     self.iser.enable_interrupt(interrupt);
   }

--- a/altos-rust/port/cortex-m0/src/interrupt/mod.rs
+++ b/altos-rust/port/cortex-m0/src/interrupt/mod.rs
@@ -10,6 +10,10 @@ mod enable;
 mod pending;
 mod priority;
 
+pub fn nvic() -> NVIC {
+  NVIC::nvic()
+}
+
 #[derive(Copy, Clone)]
 pub struct NVIC {
   mem_addr: *const u32,
@@ -25,7 +29,7 @@ impl Control for NVIC {
 }
 
 impl NVIC {
-  pub fn nvic() -> Self {
+  fn nvic() -> Self {
     const NVIC_ADDR: *const u32 = 0xE000E100 as *const _;
     NVIC {
       mem_addr: NVIC_ADDR,

--- a/altos-rust/port/cortex-m0/src/lib.rs
+++ b/altos-rust/port/cortex-m0/src/lib.rs
@@ -76,9 +76,9 @@ pub mod kernel {
 #[lang = "panic_fmt"]
 extern "C" fn panic_fmt(fmt: core::fmt::Arguments,
                         (file, line): (&'static str, u32)) -> ! {
-    println!("Panicked");
-    println!("File: {}, Line: {}", file, line);
-    println!("{}", fmt);
+    unsafe { arm::asm::disable_interrupts() };
+    kprintln!("Panicked at File: {}, Line: {}", file, line);
+    kprintln!("{}", fmt);
     loop {
         unsafe {
             arm::asm::bkpt();

--- a/altos-rust/port/cortex-m0/src/peripheral/usart/mod.rs
+++ b/altos-rust/port/cortex-m0/src/peripheral/usart/mod.rs
@@ -16,6 +16,7 @@ use self::tdr::TDR;
 use self::isr::ISR;
 use self::defs::*;
 use peripheral::{rcc, gpio};
+use interrupt;
 
 pub use self::control::{WordLength, Mode, Parity, StopLength, HardwareFlowControl};
 pub use self::baudr::BaudRate;
@@ -189,6 +190,10 @@ pub fn init() {
     let cr = rcc.get_system_clock_rate();
     usart2.set_baud_rate(BaudRate::Hz9600, cr);
 
-//    usart2.enable_transmit_interrupt();
+    usart2.enable_transmit_interrupt();
     usart2.enable_usart();
+
+    let nvic = interrupt::nvic();
+    // TODO: This argument should be replaced by an enum in the `interrupt` module
+    nvic.enable_interrupt(28);
 }

--- a/altos-rust/src/lib.rs
+++ b/altos-rust/src/lib.rs
@@ -93,6 +93,7 @@ fn blink_sleep(_args: &mut Args) {
 fn print_task(_args: &mut Args) {
     loop {
         println!("Hello World");
+        panic!("WHAT THE HELL DID YOU DO?!?!?!?");
     }
     loop {}
 }

--- a/altos-rust/src/lib.rs
+++ b/altos-rust/src/lib.rs
@@ -33,7 +33,7 @@ pub fn application_entry() -> ! {
     kernel::syscall::new_task(blink_1, Args::empty(), 512, Priority::Normal, "blink_1");
     kernel::syscall::new_task(blink_2, Args::empty(), 512, Priority::Normal, "blink_2");
     kernel::syscall::new_task(blink_sleep, Args::empty(), 512, Priority::Normal, "blink_3");
-    kernel::syscall::new_task(print_task, Args::empty(), 512, Priority::Normal, "print_task");
+    kernel::syscall::new_task(print_task, Args::empty(), 1024, Priority::Normal, "print_task");
     kernel::task::start_scheduler();
 
     loop { unsafe { arm::asm::bkpt() }; }
@@ -91,6 +91,8 @@ fn blink_sleep(_args: &mut Args) {
 }
 
 fn print_task(_args: &mut Args) {
-    println!("Hello World");
+    loop {
+        println!("Hello World");
+    }
     loop {}
 }


### PR DESCRIPTION
@RJ-Russell 

So turns out there's a separate bit we have to set to actually enable the interrupt vector to be called. The TXEIE bit just sets an interrupt pending, but if the bit in the NVIC isn't set it will never actually call the interrupt.

Also, as I found out, the interrupt will get called as long as the TXE bit is high, which means we can't just wait for the interrupt handler to wakeup our task because it will just loop infinitely. So we have to write to the TDR from within the handler in order to clear the TXE bit and get back to userspace.

So I wrote a little ringbuffer type to help dealing with stuff like this. In our write we just fill as much of the buffer as we can, then enable the TXEIE so our interrupt handler gets called. The interrupt handler just grabs a byte out of the buffer and writes it to TDR then returns. Every time TXE goes high (so we can write another byte) the handler gets called. Once the buffer is empty we just wake up whatever task was sleeping on the USART2_CHAN and disable the TXEIE bit so we stop handling TXE assertions. Then that task either continues doing whatever else it was doing or if it has more bytes to write it puts those into the buffer. 