### PR TITLE
Move kprint! macro into its own crate

### DIFF
--- a/altos-rust/Cargo.lock
+++ b/altos-rust/Cargo.lock
@@ -3,9 +3,14 @@ name = "volatile"
 version = "0.1.0"
 
 [[package]]
+name = "altos-macros"
+version = "0.1.0"
+
+[[package]]
 name = "altos_core"
 version = "0.1.0"
 dependencies = [
+ "altos-macros 0.1.0",
  "bump_allocator 0.1.0",
  "cm0_atomic 0.1.0",
  "volatile 0.1.0",
@@ -26,6 +31,7 @@ version = "0.1.0"
 name = "bump_allocator"
 version = "0.1.0"
 dependencies = [
+ "altos-macros 0.1.0",
  "cm0_atomic 0.1.0",
 ]
 
@@ -37,6 +43,7 @@ version = "0.1.0"
 name = "cortex_m0"
 version = "0.1.0"
 dependencies = [
+ "altos-macros 0.1.0",
  "altos_core 0.1.0",
  "arm 0.1.0",
 ]

--- a/altos-rust/altos-core/Cargo.toml
+++ b/altos-rust/altos-core/Cargo.toml
@@ -17,6 +17,7 @@ test = []
 [dependencies]
 bump_allocator = { path = "libs/heap/bump_allocator", optional = true }
 volatile = { path = "../libs/volatile" }
+altos-macros = { path = "libs/altos-macros" }
 
 [target.thumbv6m-none-eabi.dependencies]
 cm0_atomic = { path = "libs/cm0_atomic" }

--- a/altos-rust/altos-core/libs/altos-macros/Cargo.toml
+++ b/altos-rust/altos-core/libs/altos-macros/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "altos-macros"
+version = "0.1.0"
+authors = ["Daniel Seitz <dnseitz@gmail.com>"]
+
+[dependencies]

--- a/altos-rust/altos-core/libs/altos-macros/src/lib.rs
+++ b/altos-rust/altos-core/libs/altos-macros/src/lib.rs
@@ -15,41 +15,34 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-// arch/test.rs
-// AltOS Rust
-//
-// Created by Daniel Seitz on 1/7/17
+#![no_std]
 
-//! This module is used to provide stubs for the architecture layer for testing.
+use core::fmt;
 
-use volatile::Volatile;
-use task::args::Args;
-use alloc::boxed::Box;
-use sched;
-
-pub fn yield_cpu() {
-  // no-op
-  sched::switch_context();
+#[macro_export]
+macro_rules! kprint {
+    ($($arg:tt)*) => ({
+        $crate::debug_print(format_args!($($arg)*));
+    });
 }
 
-pub fn initialize_stack(stack_ptr: Volatile<usize>, _code: fn(&mut Args), _args: &Box<Args>) -> usize {
-  // no-op
-  stack_ptr.as_ptr() as usize
+#[macro_export]
+macro_rules! kprintln {
+    ($fmt:expr) => (kprint!(concat!($fmt, "\n")));
+    ($fmt:expr, $($arg:tt)*) => (kprint!(concat!($fmt, "\n"), $($arg)*));
 }
 
-pub fn start_first_task() {
-  // no-op
-}
-pub fn in_kernel_mode() -> bool {
-  // no-op
-  true
+#[allow(improper_ctypes)]
+extern "Rust" {
+  fn debug_fmt(args: fmt::Arguments);
 }
 
-pub fn begin_critical() -> usize {
-  // no-op
-  0
-}
-
-pub fn end_critical(_mask: usize) {
-  // no-op
+#[doc(hidden)]
+pub fn debug_print(args: fmt::Arguments) {
+    #[cfg(not(test))]
+    unsafe {
+        debug_fmt(args);
+    }
+    #[cfg(test)]
+    print!(args);
 }

--- a/altos-rust/altos-core/libs/heap/bump_allocator/Cargo.toml
+++ b/altos-rust/altos-core/libs/heap/bump_allocator/Cargo.toml
@@ -3,5 +3,8 @@ name = "bump_allocator"
 version = "0.1.0"
 authors = ["Daniel Seitz <dnseitz@gmail.com>"]
 
+[dependencies]
+altos-macros = { path = "../../altos-macros" }
+
 [target.thumbv6m-none-eabi.dependencies]
 cm0_atomic = { path = "../../cm0_atomic" }

--- a/altos-rust/altos-core/libs/heap/bump_allocator/src/lib.rs
+++ b/altos-rust/altos-core/libs/heap/bump_allocator/src/lib.rs
@@ -30,6 +30,9 @@ extern crate std;
 #[cfg(all(target_arch="arm", not(target_has_atomic="ptr")))]
 extern crate cm0_atomic as atomic;
 
+#[macro_use]
+extern crate altos_macros;
+
 #[cfg(target_has_atomic="ptr")]
 use core::sync::atomic as atomic;
 use atomic::{AtomicUsize, ATOMIC_USIZE_INIT, Ordering};
@@ -67,6 +70,7 @@ impl BumpAllocator {
   /// Allocates a block of memory with the given size and alignment.
   #[inline(never)]
   pub fn allocate(&self, size: usize, align: usize) -> Option<*mut u8> {
+    kprintln!("Allocating {} bytes", size);
     loop {
       let old_next = self.next.load(Ordering::SeqCst);
       let alloc_start = align_up(old_next, align);

--- a/altos-rust/altos-core/src/arch/cm0.rs
+++ b/altos-rust/altos-core/src/arch/cm0.rs
@@ -24,12 +24,6 @@ use volatile::Volatile;
 use task::args::Args;
 use alloc::boxed::Box;
 use syscall;
-use core::fmt;
-
-#[allow(improper_ctypes)]
-extern "Rust" {
-  fn debug_fmt(args: fmt::Arguments);
-}
 
 pub fn yield_cpu() {
   const ICSR_ADDR: usize = 0xE000_ED04;
@@ -130,11 +124,6 @@ pub fn end_critical(primask: usize) {
       : /* no clobbers */
       : "volatile");
   }
-}
-
-#[doc(hidden)]
-pub fn debug_print(args: fmt::Arguments) {
-  unsafe { debug_fmt(args) };
 }
 
 fn exit_error() -> ! {

--- a/altos-rust/altos-core/src/arch/unknown.rs
+++ b/altos-rust/altos-core/src/arch/unknown.rs
@@ -26,7 +26,6 @@ use volatile::Volatile;
 use task::args::Args;
 use alloc::boxed::Box;
 use sched;
-use core::fmt;
 
 extern "Rust" {
   fn __yield_cpu();
@@ -35,7 +34,6 @@ extern "Rust" {
   fn __in_kernel_mode() -> bool;
   fn __begin_critical() -> usize;
   fn __end_critical(mask: usize);
-  fn __debug_print(args: fmt::Arguments);
 }
 
 pub fn yield_cpu() {
@@ -60,8 +58,4 @@ pub fn begin_critical() -> usize {
 
 pub fn end_critical(mask: usize) {
   unsafe { __end_critical(mask) };
-}
-
-pub fn debug_print(args: fmt::Arguments) {
-  unsafe { __debug_fmt(args) };
 }

--- a/altos-rust/altos-core/src/lib.rs
+++ b/altos-rust/altos-core/src/lib.rs
@@ -43,18 +43,8 @@
 #[macro_use]
 extern crate std;
 
-#[macro_export]
-macro_rules! kprint {
-    ($($arg:tt)*) => ({
-        $crate::debug_print(format_args!($($arg)*));
-    });
-}
-
-#[macro_export]
-macro_rules! kprintln {
-    ($fmt:expr) => (kprint!(concat!($fmt, "\n")));
-    ($fmt:expr, $($arg:tt)*) => (kprint!(concat!($fmt, "\n"), $($arg)*));
-}
+#[macro_use]
+extern crate altos_macros;
 
 #[cfg(all(not(test), not(feature="test"), feature="bump_allocator"))]
 extern crate bump_allocator as allocator;
@@ -94,4 +84,3 @@ pub use core::sync::atomic as atomic;
 pub use task::{TaskHandle, Priority};
 pub use sched::{CURRENT_TASK, switch_context, start_scheduler};
 pub use task::args;
-pub use arch::debug_print;

--- a/altos-rust/port/cortex-m0/Cargo.toml
+++ b/altos-rust/port/cortex-m0/Cargo.toml
@@ -21,6 +21,7 @@ features = ["test"]
 [dependencies]
 #compiler_builtins = { git = "https://github.com/rust-lang-nursery/compiler-builtins" }
 arm = { path = "libs/arm" }
+altos-macros = { path = "../../altos-core/libs/altos-macros" }
 
 [dependencies.altos_core]
 path = "../../altos-core"

--- a/altos-rust/port/cortex-m0/src/lib.rs
+++ b/altos-rust/port/cortex-m0/src/lib.rs
@@ -34,8 +34,9 @@
 #[macro_use]
 extern crate std;
 
-#[macro_use]
 extern crate altos_core;
+#[macro_use]
+extern crate altos_macros;
 
 pub extern crate arm;
 //pub extern crate compiler_builtins; // See above comment
@@ -43,7 +44,6 @@ pub extern crate arm;
 #[cfg(test)]
 mod test;
 
-#[macro_use]
 pub mod io;
 mod exceptions;
 mod interrupt;


### PR DESCRIPTION
This allows underlying crates like memory allocators to use the
`kprint!` macro for debug printing to the serial port.

@pdouglas94 