### PR TITLE
Fix data alignment issue

### DIFF
--- a/altos-rust/cortex_m0.ld
+++ b/altos-rust/cortex_m0.ld
@@ -35,6 +35,7 @@ SECTIONS
     *(.ARM.extab*)
   } > FLASH
 
+  . = ALIGN(4);
   /* Used by startup to initialize data */
   _sidata = .;
 


### PR DESCRIPTION
The `_sidata` symbol was not being force aligned on a 4 byte value. The
`ldr` instruction can only load values which are 4 byte aligned, so in
some cases this was causing a hard fault if the `_sidata` symbol was
improperly aligned. This patch just forces the symbol onto a 4 byte
boundry.

@pdouglas94 