### PR TITLE
Fix linker bug causing wrong entry point

### DIFF
--- a/altos-rust/cortex_m0.ld
+++ b/altos-rust/cortex_m0.ld
@@ -18,11 +18,11 @@ SECTIONS
   {
     /* Vector Table */
     LONG(_stack_start);
-    LONG(_reset + 1);
+    LONG(_entry + 1);
     KEEP(*(.rodata._EXCEPTIONS));
 
     /* Reset Handler */
-    _reset = .;
+    _entry = .;
     *(.text._reset);
 
     *(.text*);


### PR DESCRIPTION
Using an updated version of the linker seems to have fixed a bug
(feature?) that we were inadvertently abusing. I'm guessing it's a
naming conflict between the section name `_reset` that we were using and
the linker variable that was used to mark the reset section (both were
using the `_reset` name). This just changes the linker variable to
`_entry` to avoid a name conflict. That's what I think is going on at
least.

@RJ-Russell 