### PR TITLE
Fix Modulo division

### DIFF
--- a/altos-rust/port/cortex-m0/libs/arm/src/lib.rs
+++ b/altos-rust/port/cortex-m0/libs/arm/src/lib.rs
@@ -18,6 +18,7 @@
 #![no_std]
 #![feature(asm)]
 #![feature(naked_functions)]
+#![feature(core_intrinsics)]
 
 // NOTE: A lot of these functions are taken from other sources, one very useful resource is
 // https://github.com/rust-lang-nursery/compiler-builtins

--- a/altos-rust/port/cortex-m0/libs/arm/src/lib.rs
+++ b/altos-rust/port/cortex-m0/libs/arm/src/lib.rs
@@ -18,7 +18,7 @@
 #![no_std]
 #![feature(asm)]
 #![feature(naked_functions)]
-#![feature(core_intrinsics)]
+#![cfg_attr(target_arch="arm", feature(core_intrinsics))]
 
 // NOTE: A lot of these functions are taken from other sources, one very useful resource is
 // https://github.com/rust-lang-nursery/compiler-builtins

--- a/altos-rust/port/cortex-m0/libs/arm/src/math.rs
+++ b/altos-rust/port/cortex-m0/libs/arm/src/math.rs
@@ -42,35 +42,35 @@ pub extern "C" fn __aeabi_uidiv(num: u32, den: u32) -> u32 {
 
 #[no_mangle]
 pub extern "C" fn __udivmodsi4(mut num: u32, mut den: u32, rem_p: Option<&mut u32>) -> u32 {
-	let mut quot = 0;
-	let mut qbit = 1;
+    let mut quot = 0;
+    let mut qbit = 1;
 
-	if den == 0 {
-		return 0;
-	}
-
-	/*
-	 * left-justify denominator and count shift
-	 */
-	while den as i32 >= 0 {
-		den <<= 1;
-		qbit <<= 1;
-	}
-
-	while qbit != 0 {
-		if den <= num {
-			num -= den;
-			quot += qbit;
-		}
-		den >>= 1;
-		qbit >>= 1;
-	}
-
-	if let Some(rem) = rem_p {
-		*rem = num;
+    if den == 0 {
+        return 0;
     }
 
-	return quot;
+    /*
+     * left-justify denominator and count shift
+     */
+    while den as i32 >= 0 {
+        den <<= 1;
+        qbit <<= 1;
+    }
+
+    while qbit != 0 {
+        if den <= num {
+            num -= den;
+            quot += qbit;
+        }
+        den >>= 1;
+        qbit >>= 1;
+    }
+
+    if let Some(rem) = rem_p {
+        *rem = num;
+    }
+
+    return quot;
 }
 
 #[no_mangle]
@@ -82,7 +82,8 @@ pub unsafe fn __aeabi_uidivmod() {
           bl __udivmodsi4
           ldr r1, [sp]
           add sp, sp, #4
-          pop {pc}");
+          pop {pc}"
+    );
     ::core::intrinsics::unreachable();
 }
 
@@ -107,45 +108,45 @@ fn __aeabi_uidivbase(mut num: u32, mut den: u32, modwanted: bool) -> u32 {
 
 #[cfg(test)]
 mod tests {
-  use super::*;
+    use super::*;
 
-  #[test]
-  fn divide_even() {
-    assert_eq!(10, __aeabi_uidiv(100, 10));
-  }
+    #[test]
+    fn divide_even() {
+        assert_eq!(10, __aeabi_uidiv(100, 10));
+    }
 
-  #[test]
-  fn divide_uneven() {
-    assert_eq!(10, __aeabi_uidiv(105, 10));
-  }
+    #[test]
+    fn divide_uneven() {
+        assert_eq!(10, __aeabi_uidiv(105, 10));
+    }
 
-  #[test]
-  fn divide_denominator_bigger() {
-    assert_eq!(0, __aeabi_uidiv(5, 10));
-  }
+    #[test]
+    fn divide_denominator_bigger() {
+        assert_eq!(0, __aeabi_uidiv(5, 10));
+    }
 
-  #[test]
-  fn mod_even() {
-    assert_eq!(0, __aeabi_uidivmod(100, 10));
-  }
+    #[test]
+    fn mod_even() {
+        assert_eq!(0, __aeabi_uidivmod(100, 10));
+    }
 
-  #[test]
-  fn mod_uneven() {
-    assert_eq!(5, __aeabi_uidivmod(105, 10));
-  }
+    #[test]
+    fn mod_uneven() {
+        assert_eq!(5, __aeabi_uidivmod(105, 10));
+    }
 
-  #[test]
-  fn mod_denominator_bigger() {
-    assert_eq!(5, __aeabi_uidivmod(5, 10));
-  }
+    #[test]
+    fn mod_denominator_bigger() {
+        assert_eq!(5, __aeabi_uidivmod(5, 10));
+    }
 
-  #[test]
-  fn multiply_bigger_first() {
-    assert_eq!(100, __aeabi_lmul(20, 5));
-  }
+    #[test]
+    fn multiply_bigger_first() {
+        assert_eq!(100, __aeabi_lmul(20, 5));
+    }
 
-  #[test]
-  fn multiply_bigger_second() {
-    assert_eq!(100, __aeabi_lmul(5, 20));
-  }
+    #[test]
+    fn multiply_bigger_second() {
+        assert_eq!(100, __aeabi_lmul(5, 20));
+    }
 }

--- a/altos-rust/port/cortex-m0/libs/arm/src/math.rs
+++ b/altos-rust/port/cortex-m0/libs/arm/src/math.rs
@@ -73,6 +73,7 @@ pub extern "C" fn __udivmodsi4(mut num: u32, mut den: u32, rem_p: Option<&mut u3
     return quot;
 }
 
+#[cfg(target_arch="arm")]
 #[no_mangle]
 #[naked]
 pub unsafe fn __aeabi_uidivmod() {
@@ -111,42 +112,48 @@ mod tests {
     use super::*;
 
     #[test]
-    fn divide_even() {
+    fn test_divide_even() {
         assert_eq!(10, __aeabi_uidiv(100, 10));
     }
 
     #[test]
-    fn divide_uneven() {
+    fn test_divide_uneven() {
         assert_eq!(10, __aeabi_uidiv(105, 10));
     }
 
     #[test]
-    fn divide_denominator_bigger() {
+    fn test_divide_denominator_bigger() {
         assert_eq!(0, __aeabi_uidiv(5, 10));
     }
 
     #[test]
-    fn mod_even() {
-        assert_eq!(0, __aeabi_uidivmod(100, 10));
+    fn test_mod_even() {
+        let mut rem: u32 = !0;
+        assert_eq!(10, __udivmodsi4(100, 10, Some(&mut rem)));
+        assert_eq!(0, rem);
     }
 
     #[test]
-    fn mod_uneven() {
-        assert_eq!(5, __aeabi_uidivmod(105, 10));
+    fn test_mod_uneven() {
+        let mut rem: u32 = !0;
+        assert_eq!(10, __udivmodsi4(105, 10, Some(&mut rem)));
+        assert_eq!(5, rem);
     }
 
     #[test]
-    fn mod_denominator_bigger() {
-        assert_eq!(5, __aeabi_uidivmod(5, 10));
+    fn test_mod_denominator_bigger() {
+        let mut rem: u32 = !0;
+        assert_eq!(0, __udivmodsi4(5, 10, Some(&mut rem)));
+        assert_eq!(5, rem);
     }
 
     #[test]
-    fn multiply_bigger_first() {
+    fn test_multiply_bigger_first() {
         assert_eq!(100, __aeabi_lmul(20, 5));
     }
 
     #[test]
-    fn multiply_bigger_second() {
+    fn test_multiply_bigger_second() {
         assert_eq!(100, __aeabi_lmul(5, 20));
     }
 }


### PR DESCRIPTION
The compiler builtin function being called for modulo division
`__aeabi_uidivmod` uses a special calling convention that was not being
adhered to. In order to get around this we must implement the function
in assembly to match the requirements of the calling convention.
The issue was discovered from:
https://github.com/rust-lang-nursery/compiler-builtins/blob/master/src/arm.rs
(See the note at the top of the file)

This fixes #28 and #53 
@pdouglas94 @RJ-Russell 