### PR TITLE
Refactor Task module and Mutex/CondVar types

### DIFF
--- a/altos-rust/altos-core/src/queue/queue.rs
+++ b/altos-rust/altos-core/src/queue/queue.rs
@@ -246,29 +246,6 @@ impl<T> Queue<T> {
         self.head.is_none()
     }
 
-    /// Returns an iterator over the values of `self` consuming `self`.
-    ///
-    /// # Examples
-    ///
-    /// ```rust,no_run
-    /// use altos_core::queue::{Node, Queue};
-    /// use altos_core::alloc::boxed::Box;
-    ///
-    /// let mut queue = Queue::new();
-    /// queue.enqueue(Box::new(Node::new(1)));
-    /// queue.enqueue(Box::new(Node::new(2)));
-    /// queue.enqueue(Box::new(Node::new(3)));
-    ///
-    /// let mut iter = queue.into_iter();
-    /// assert_eq!(iter.next().map(|n| **n), Some(1));
-    /// assert_eq!(iter.next().map(|n| **n), Some(2));
-    /// assert_eq!(iter.next().map(|n| **n), Some(3));
-    /// assert!(iter.next().is_none());
-    /// ```
-    pub fn into_iter(self) -> IntoIter<T> {
-        IntoIter(self)
-    }
-
     /// Returns an iterator over references to the values in `self`.
     ///
     /// # Examples
@@ -313,6 +290,15 @@ impl<T> Queue<T> {
     /// ```
     pub fn iter_mut(&mut self) -> IterMut<T> {
         IterMut { next: self.head.as_mut().map(|node| &mut **node) }
+    }
+}
+
+impl<T> IntoIterator for Queue<T> {
+    type Item = Box<Node<T>>;
+    type IntoIter = IntoIter<T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        IntoIter(self)
     }
 }
 

--- a/altos-rust/altos-core/src/sched/mod.rs
+++ b/altos-rust/altos-core/src/sched/mod.rs
@@ -71,7 +71,7 @@ pub fn switch_context() {
                     panic!("switch_context - The current task's stack overflowed!");
                 }
                 if running.state == State::Blocked {
-                    match running.delay_type {
+                    match running.delay_type() {
                         Delay::Timeout => DELAY_QUEUE.enqueue(running),
                         Delay::Overflowed => OVERFLOW_DELAY_QUEUE.enqueue(running),
                         Delay::Sleep => SLEEP_QUEUE.enqueue(running),
@@ -80,8 +80,7 @@ pub fn switch_context() {
                         ),
                     }
                 } else {
-                    running.state = State::Ready;
-                    running.delay_type = Delay::Invalid;
+                    running.set_ready();
                     PRIORITY_QUEUES[queue_index].enqueue(running);
                 }
             }

--- a/altos-rust/altos-core/src/sched/mod.rs
+++ b/altos-rust/altos-core/src/sched/mod.rs
@@ -124,6 +124,9 @@ fn select_task<I: Iterator<Item=Priority>>(priorities: I) -> Box<Node<TaskContro
 /// Start running the first task in the queue.
 pub fn start_scheduler() {
     task::init_idle_task();
+    // UNSAFE: Accessing CURRENT_TASK
+    unsafe { CURRENT_TASK = Some(select_task(Priority::all())) };
+    /*
     for i in Priority::all() {
         if let Some(mut task) = PRIORITY_QUEUES[i].dequeue() {
             task.set_running();
@@ -132,6 +135,7 @@ pub fn start_scheduler() {
             break;
         }
     }
+    */
     // UNSAFE: Accessing CURRENT_TASK
     debug_assert!(unsafe { CURRENT_TASK.is_some() });
     arch::start_first_task();

--- a/altos-rust/altos-core/src/sched/mod.rs
+++ b/altos-rust/altos-core/src/sched/mod.rs
@@ -126,18 +126,6 @@ pub fn start_scheduler() {
     task::init_idle_task();
     // UNSAFE: Accessing CURRENT_TASK
     unsafe { CURRENT_TASK = Some(select_task(Priority::all())) };
-    /*
-    for i in Priority::all() {
-        if let Some(mut task) = PRIORITY_QUEUES[i].dequeue() {
-            task.set_running();
-            // UNSAFE: Accessing CURRENT_TASK
-            unsafe { CURRENT_TASK = Some(task) };
-            break;
-        }
-    }
-    */
-    // UNSAFE: Accessing CURRENT_TASK
-    debug_assert!(unsafe { CURRENT_TASK.is_some() });
     arch::start_first_task();
 }
 

--- a/altos-rust/altos-core/src/sync/condvar.rs
+++ b/altos-rust/altos-core/src/sync/condvar.rs
@@ -56,11 +56,12 @@ impl CondVar {
 
         self.verify(mutex);
 
+        ::syscall::condvar_wait(self, guard);
         // unlock the mutex
-        drop(guard);
+        //drop(guard);
 
         // Sleep on the cond var channel
-        ::syscall::sleep(self as *const _ as usize);
+        //::syscall::sleep(self as *const _ as usize);
 
         // re-acquire lock before returning
         mutex.lock()

--- a/altos-rust/altos-core/src/sync/condvar.rs
+++ b/altos-rust/altos-core/src/sync/condvar.rs
@@ -18,7 +18,7 @@
 //! Condition variable.
 
 use atomic::{AtomicUsize, ATOMIC_USIZE_INIT, Ordering};
-use sync::mutex::{MutexGuard, Mutex};
+use sync::mutex::{RawMutex, MutexGuard};
 
 /// A Condition Variable
 ///
@@ -38,46 +38,48 @@ unsafe impl Send for CondVar {}
 unsafe impl Sync for CondVar {}
 
 impl CondVar {
-    /// Creates a new `CondVar` which is ready to be used.
+    /// Create a new `CondVar` which is ready to be used.
     pub const fn new() -> Self {
         CondVar {
             mutex: ATOMIC_USIZE_INIT,
         }
     }
 
-    /// Blocks the current task until this condition variable recieves a notification.
+    /// Block the current task until this condition variable recieves a notification.
     ///
     /// This function will automatically unlock the mutex represented by the guard passed in and
     /// block the current task. Calls to notify after the mutex is unlocked can wake up this task.
     /// When this call returns, the lock will have been reacquired.
-    pub fn wait<'a, T>(&self, guard: MutexGuard<'a, T>) -> MutexGuard<'a, T> {
-        // Get a reference to the locked mutex
-        let mutex = ::sync::mutex_from_guard(&guard);
+    ///
+    /// # Panics
+    ///
+    /// This call will panic if more than one distinct `Mutex` is used to wait with.
+    pub fn wait<'a, T>(&self, guard: &MutexGuard<'a, T>) {
+        // UNSAFE: Get a reference to the locked mutex so we can unlock it before going to sleep,
+        // we are holding the `MutexGuard` invariant by reacquiring the lock before returning from
+        // this function.
+        let raw_mutex = unsafe { ::sync::mutex_from_guard(guard) };
 
-        self.verify(mutex);
+        self.verify(raw_mutex);
 
-        ::syscall::condvar_wait(self, guard);
-        // unlock the mutex
-        //drop(guard);
-
-        // Sleep on the cond var channel
-        //::syscall::sleep(self as *const _ as usize);
+        ::syscall::condvar_wait(self, raw_mutex);
 
         // re-acquire lock before returning
-        mutex.lock()
+        ::syscall::mutex_lock(raw_mutex);
     }
 
-    /// Wakes up all tasks that are blocked on this condition variable.
+    /// Wake up all tasks that are blocked on this condition variable.
     ///
     /// This method will wake up any waiters on this condition variable. The calls to
     /// `notify_all()` are not buffered in any way. Calling `wait()` on another thread after
     /// calling `notify_all()` will still block the thread.
     pub fn notify_all(&self) {
-        ::syscall::wake(self as *const _ as usize);
+        ::syscall::condvar_broadcast(self);
     }
 
-    fn verify<T>(&self, mutex: &Mutex<T>) {
-        let addr = mutex as *const _ as usize;
+    // Verify that only one mutex is being used on this condition variable at a time
+    fn verify(&self, mutex: &RawMutex) {
+        let addr = mutex.address();
         match self.mutex.compare_and_swap(0, addr, Ordering::SeqCst) {
             // We have successfully bound the mutex
             0 => {},
@@ -113,10 +115,10 @@ mod tests {
 
         // Because these mutex locks don't actually put the running thread to sleep we need to simulate
         // two tasks running in parallel and watch what the current task is to see which is 'running'
-        let mut guard = mutex.lock();
+        let guard = mutex.lock();
 
         // We should be in task 2 after the wait
-        guard = condvar.wait(guard);
+        condvar.wait(&guard);
         assert_eq!(handle_1.state(), Ok(State::Blocked));
         assert!(test::current_task().is_some());
         assert_eq!(handle_2.tid(), Ok(test::current_task().unwrap().tid()));
@@ -143,7 +145,10 @@ mod tests {
         assert!(test::current_task().is_some());
         assert_eq!(handle_1.tid(), Ok(test::current_task().unwrap().tid()));
 
-        drop(guard);
+        // Don't drop the guard because we actually don't care about releasing the lock at the very
+        // end, and it will actually cause the test to panic if we don't end on the task that
+        // initially acquired the lock, which seems irrelavant to this test.
+        ::core::mem::forget(guard);
     }
 
     #[test]
@@ -157,8 +162,8 @@ mod tests {
         let guard1 = mutex1.lock();
         let guard2 = mutex2.lock();
 
-        condvar.wait(guard1);
-        condvar.wait(guard2);
+        condvar.wait(&guard1);
+        condvar.wait(&guard2);
     }
 
     #[test]
@@ -174,15 +179,15 @@ mod tests {
         assert_eq!(handle_1.tid(), Ok(test::current_task().unwrap().tid()));
 
         // See smoke test for details
-        let mut guard = mutex.lock();
+        let guard = mutex.lock();
         // Task 1 waits on condvar
-        guard = condvar.wait(guard);
+        condvar.wait(&guard);
         assert_eq!(handle_1.state(), Ok(State::Blocked));
         // Task 2 waits on condvar
-        guard = condvar.wait(guard);
+        condvar.wait(&guard);
         assert_eq!(handle_2.state(), Ok(State::Blocked));
         // Task 3 waits on condvar
-        guard = condvar.wait(guard);
+        condvar.wait(&guard);
         assert_eq!(handle_3.state(), Ok(State::Blocked));
         assert!(test::current_task().is_some());
         assert_eq!(handle_4.tid(), Ok(test::current_task().unwrap().tid()));
@@ -219,6 +224,9 @@ mod tests {
         assert!(test::current_task().is_some());
         assert_eq!(handle_4.tid(), Ok(test::current_task().unwrap().tid()));
 
-        drop(guard);
+        // Don't drop the guard because we actually don't care about releasing the lock at the very
+        // end, and it will actually cause the test to panic if we don't end on the task that
+        // initially acquired the lock, which seems irrelavant to this test.
+        ::core::mem::forget(guard);
     }
 }

--- a/altos-rust/altos-core/src/sync/mod.rs
+++ b/altos-rust/altos-core/src/sync/mod.rs
@@ -26,7 +26,8 @@ mod spin;
 mod critical;
 mod condvar;
 
-pub use self::mutex::{Mutex, MutexGuard};
+pub use self::mutex::{RawMutex, Mutex, MutexGuard};
+pub use self::mutex::{LockResult, LockError, UnlockError};
 pub use self::mutex::mutex_from_guard;
 pub use self::spin::{SpinMutex, SpinGuard};
 pub use self::critical::CriticalSection;

--- a/altos-rust/altos-core/src/sync/mutex.rs
+++ b/altos-rust/altos-core/src/sync/mutex.rs
@@ -26,17 +26,69 @@
 //! could have been waiting on the same resource and woken up first. If this is the case, then that
 //! other thread could now be holding the lock.
 
-use atomic::{ATOMIC_BOOL_INIT, AtomicBool, Ordering};
+use atomic::{ATOMIC_USIZE_INIT, AtomicUsize, Ordering};
 use core::ops::{Drop, Deref, DerefMut};
 use core::cell::UnsafeCell;
 use syscall;
+
+const LOCK_MASK: usize = ::core::isize::MIN as usize;
+const UNLOCKED: usize = 0;
+const HOLDER_MASK: usize = !LOCK_MASK;
+
+/// A result type for locking operations
+///
+/// This result will only carry error information about why a locking operation has failed,
+/// otherwise if an operation was successful there is no data to pass on to the calling routine.
+pub type LockResult<E> = Result<(), E>;
+
+/// Errors that can occur when trying to acquire a lock
+///
+/// When attempting to acquire a lock, there are several issues that can be encountered. If a lock
+/// is already owned, it could potentially cause deadlock, so it is best to return an error
+/// expressing such a condition has occurred. Otherwise, the most common error state to run into
+/// would be if the lock is already held by another thread.
+pub enum LockError {
+    /// The lock is already held by the thread trying to acquire it
+    AlreadyOwned,
+
+    /// The lock is held by another thread
+    Locked,
+}
+
+/// Errors that can occur when trying to release a lock
+///
+/// When trying to release a lock, the only truly valid state should be when the releasing thread
+/// is also the holder of the lock.
+pub enum UnlockError {
+    /// The lock is not held by any thread currently
+    NotLocked,
+
+    /// The lock is held by a thread other than the releasing thread
+    NotOwned,
+}
+
+/// A mutex primitive for locking and unlocking
+///
+/// This primitive will keep track of which thread holds ownership over it. The locking and
+/// unlocking functions on this type will return a `LockResult` carrying information about any
+/// issues that may have been encountered while trying to change the state of the lock. These range
+/// from common conditions like another thread holding the lock that is trying to be acquired, to
+/// more serious ones such as a thread trying to acquire a lock it already holds.
+///
+/// This primitive is for very fine grained operations around shared resources, if you require a
+/// more managed locking primitive use the `Mutex` type, which is a wrapper around this type.
+pub struct RawMutex {
+    lock: AtomicUsize,
+}
 
 /// A mutex lock to synchronize access to some shared resource.
 ///
 /// If the lock is already held by another thread when the running thread tries to obtain it then
 /// it will block and another task will be selected to run.
+// We need this to be `repr(C)` because we need the lock field to be the first field in memory
+#[repr(C)]
 pub struct Mutex<T: ?Sized> {
-    lock: AtomicBool,
+    lock: RawMutex,
     data: UnsafeCell<T>,
 }
 
@@ -46,32 +98,106 @@ pub struct Mutex<T: ?Sized> {
 /// then use that guard to access the shared data. When the guard goes out of scope, the lock will
 /// automatically be freed.
 pub struct MutexGuard<'mx, T: ?Sized + 'mx> {
-    wchan: usize,
-    lock: &'mx AtomicBool,
+    lock: &'mx RawMutex,
     data: &'mx mut T,
 }
 
 unsafe impl<T: ?Sized + Send> Sync for Mutex<T> {}
 unsafe impl<T: ?Sized + Send> Send for Mutex<T> {}
 
+impl RawMutex {
+    /// Create a new, unlocked, mutex
+    pub const fn new() -> Self {
+        RawMutex {
+            lock: ATOMIC_USIZE_INIT,
+        }
+    }
+
+    /// Attempt to acquire the lock for the given thread id
+    ///
+    /// This function will try to acquire the lock by first checking if it's already held by
+    /// anyone. If it is not held by anyone it will attempt to grab the lock with an atomic
+    /// operation, returning `Ok` if it was successfully acquired. If the lock is already held by
+    /// another thread, or another thread beats this one to locking it then this function will
+    /// return an `Err` with more information.
+    pub fn try_lock(&self, tid: usize) -> LockResult<LockError> {
+        match self.holder() {
+            // WE are the bearer of the lock...
+            Some(holder) if holder == tid => Err(LockError::AlreadyOwned),
+
+            // Someone else is holding the lock right now
+            Some(_) => Err(LockError::Locked),
+
+            // No one is holding the lock, so let's grab it if we can
+            None => {
+                if self.lock.compare_and_swap(UNLOCKED,
+                        LOCK_MASK | tid,
+                        Ordering::Acquire) != UNLOCKED {
+                    // Someone else grabbed it between the initial check and this exchange
+                    Err(LockError::Locked)
+                }
+                else {
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    /// Attempt to release the lock for the given thread id
+    ///
+    /// This function will try to release the lock. It will only succeed if the `tid` passed in is
+    /// the same as the one that was used to acquire the lock. If the mutex was not locked to begin
+    /// with an `Err` will still be returned, though it will be as if the operation had succeeded.
+    pub fn try_unlock(&self, tid: usize) -> LockResult<UnlockError> {
+        match self.holder() {
+            // We hold the lock, so we can release it
+            Some(holder) if holder == tid => {
+                self.lock.store(UNLOCKED, Ordering::Release);
+                Ok(())
+            },
+
+            // Someone else has got the lock, it's not in our rights to release it
+            Some(_) => Err(UnlockError::NotOwned),
+
+            // It's not locked...
+            None => Err(UnlockError::NotLocked),
+        }
+    }
+
+    // Get the current holder of the mutex, if one exists
+    fn holder(&self) -> Option<usize> {
+        let lock_value = self.lock.load(Ordering::Relaxed);
+
+        if lock_value == UNLOCKED {
+            None
+        }
+        else {
+            // Mask all but the top bit to get which task is currently holding the lock
+            Some(lock_value & HOLDER_MASK)
+        }
+    }
+
+    /// Get the address of this mutex in memory
+    ///
+    /// This is mainly used as a wake/sleep channel, so if a thread tries to acquire a lock but
+    /// fails it can go to sleep on the channel identified by this mutex's address. When the lock
+    /// is later released, the same address can be used to wake up the sleeping tasks.
+    pub fn address(&self) -> usize {
+        self as *const _ as usize
+    }
+}
+
 impl<T> Mutex<T> {
     /// Creates a new `Mutex` wrapping the supplied data
     pub const fn new(data: T) -> Self {
         Mutex {
-            lock: ATOMIC_BOOL_INIT,
+            lock: RawMutex::new(),
             data: UnsafeCell::new(data),
         }
     }
 }
 
 impl<T: ?Sized> Mutex<T> {
-    fn wchan(&self) -> usize {
-        &self.lock as *const _ as usize
-    }
-
-    fn obtain_lock(&self) {
-        syscall::mutex_lock(&self.lock);
-    }
 
     /// Try to obtain the lock in a blocking fashion.
     ///
@@ -93,13 +219,9 @@ impl<T: ?Sized> Mutex<T> {
     /// drop(guard); // Could just let guard drop out of scope too...
     /// ```
     pub fn lock(&self) -> MutexGuard<T> {
-        self.obtain_lock();
-        MutexGuard {
-            wchan: self.wchan(),
-            lock: &self.lock,
-            // UNSAFE: lock controls access to data, so only one thread can ever get this &mut
-            data: unsafe { &mut *self.data.get() },
-        }
+        syscall::mutex_lock(&self.lock);
+        // UNSAFE: lock controls access to data, so only one thread can ever get this &mut
+        unsafe { self.build_guard() }
     }
 
     /// Try to obtain the lock in a non-blocking fashion.
@@ -124,27 +246,35 @@ impl<T: ?Sized> Mutex<T> {
     /// }
     /// ```
     pub fn try_lock(&self) -> Option<MutexGuard<T>> {
-        if self.lock.compare_and_swap(false, true, Ordering::Acquire) == false {
-            Some(
-                MutexGuard {
-                    wchan: self.wchan(),
-                    lock: &self.lock,
-                    // UNSAFE: lock controls access to data, we only execute this branch
-                    // if we've acquired it
-                    data: unsafe { &mut *self.data.get() },
-                }
-            )
+        if syscall::mutex_try_lock(&self.lock) {
+            // UNSAFE: We are guaranteed to have acquired exclusive access over the lock if we've
+            // gotten to this case
+            Some(unsafe { self.build_guard() })
         }
         else {
             None
         }
     }
+
+    // Build a `MutexGuard` from this Mutex
+    //
+    // This is a helper function to generate a `MutexGuard` referencing the mutex, and should only
+    // be called after successfully acquiring the lock.
+    unsafe fn build_guard(&self) -> MutexGuard<T> {
+        MutexGuard {
+            lock: &self.lock,
+            data: &mut *self.data.get(),
+        }
+    }
 }
 
+// Get the underlying mutex from a `MutexGuard` so that it can be manipulated
+//
+// This should only be used in core library functions since it would allow manipulation of a mutex
+// while it is locked. Improper use can break the invariants of the `Mutex` and `MutexGuard` types.
 #[doc(hidden)]
-pub fn mutex_from_guard<'a, T>(guard: &MutexGuard<'a, T>) -> &'a Mutex<T> {
-    // UNSAFE: wchan is the address of the parent mutex, so we know it is a valid reference
-    unsafe { &*(guard.wchan as *const Mutex<T>) }
+pub unsafe fn mutex_from_guard<'a, T>(guard: &MutexGuard<'a, T>) -> &'a RawMutex {
+    &guard.lock
 }
 
 impl<'mx, T: ?Sized> Deref for MutexGuard<'mx, T> {
@@ -164,8 +294,6 @@ impl<'mx, T: ?Sized> DerefMut for MutexGuard<'mx, T> {
 impl<'mx, T: ?Sized> Drop for MutexGuard<'mx, T> {
     /// Dropping the guard will unlock the lock it came from and wake any tasks waiting on it.
     fn drop(&mut self) {
-        // Do we care if we get pre-empted and another thread steals the lock before we wake the
-        // sleeping tasks?
         syscall::mutex_unlock(self.lock);
     }
 }
@@ -178,36 +306,45 @@ mod tests {
     use syscall;
     use test;
 
+    // A temporary task id for testing
+    const TASK_ID: usize = 0;
+
     #[test]
     fn test_mutex_smoke() {
         let _g = test::set_up();
         let mutex = Mutex::new(());
+        sched::start_scheduler();
 
         let guard = mutex.lock();
         // lock and load baby
-        assert_eq!(mutex.lock.load(Ordering::Relaxed), true);
+        assert_ne!(mutex.lock.lock.load(Ordering::Relaxed), UNLOCKED);
 
         drop(guard);
-        assert_eq!(mutex.lock.load(Ordering::Relaxed), false);
+        assert_eq!(mutex.lock.lock.load(Ordering::Relaxed), UNLOCKED);
     }
 
     #[test]
-    fn test_mutex_try_lock_fails() {
-        let _g = test::set_up();
-        let mutex = Mutex::new(());
+    fn test_raw_mutex_try_lock_fails() {
+        let raw_mutex = RawMutex::new();
+        match raw_mutex.try_lock(TASK_ID) {
+            Ok(_) => assert_ne!(raw_mutex.lock.load(Ordering::Relaxed), UNLOCKED),
+            Err(_) => assert!(false, "Failed to acquire lock on first try"),
+        }
 
-        let guard = mutex.lock();
-        assert_eq!(mutex.lock.load(Ordering::Relaxed), true);
+        match raw_mutex.try_lock(TASK_ID) {
+            Ok(_) => assert!(false, "Successfully acquired lock when it should be locked"),
+            Err(_) => assert_ne!(raw_mutex.lock.load(Ordering::Relaxed), UNLOCKED),
+        }
 
-        let guard2 = mutex.try_lock();
-        assert!(guard2.is_none());
+        match raw_mutex.try_unlock(TASK_ID) {
+            Ok(_) => assert_eq!(raw_mutex.lock.load(Ordering::Relaxed), UNLOCKED),
+            Err(_) => assert!(false, "Failed to unlock owned mutex"),
+        }
 
-        drop(guard);
-        assert_eq!(mutex.lock.load(Ordering::Relaxed), false);
-
-        let guard3 = mutex.try_lock();
-        assert!(guard3.is_some());
-        assert_eq!(mutex.lock.load(Ordering::Relaxed), true);
+        match raw_mutex.try_lock(TASK_ID) {
+            Ok(_) => assert_ne!(raw_mutex.lock.load(Ordering::Relaxed), UNLOCKED),
+            Err(_) => assert!(false, "Failed to acquire lock after unlocking"),
+        }
     }
 
     #[test]
@@ -221,37 +358,40 @@ mod tests {
         assert_eq!(handle_1.tid(), Ok(test::current_task().unwrap().tid()));
 
         let guard = mutex.lock();
-        assert_eq!(mutex.lock.load(Ordering::Relaxed), true);
+        assert_ne!(mutex.lock.lock.load(Ordering::Relaxed), UNLOCKED);
 
+        // Switch to second task
+        syscall::sched_yield();
+        assert!(test::current_task().is_some());
+        assert_eq!(handle_2.tid(), Ok(test::current_task().unwrap().tid()));
+
+        // task 2 is running, let's try to acquire the lock
         // Because these locks don't actually put the thread to sleep unless our operating system
         // is running, we need to simulate a failed lock attempt by calling sleep on the
         // lock's wchan.
-        syscall::sleep(mutex.wchan());
-        assert_eq!(handle_1.state(), Ok(State::Blocked));
-        assert!(test::current_task().is_some());
-        assert_eq!(handle_2.tid(), Ok(test::current_task().unwrap().tid()));
+        syscall::sleep(mutex.lock.address());
 
-        // task 2 is simulated to have acquired the lock, lets say it holds the lock for a
+        // task 1 is simulated to have acquired the lock, lets say it holds the lock for a
         // few context switches.
         syscall::system_tick();
         assert!(test::current_task().is_some());
-        assert_eq!(handle_2.tid(), Ok(test::current_task().unwrap().tid()));
-        syscall::system_tick();
-        assert!(test::current_task().is_some());
-        assert_eq!(handle_2.tid(), Ok(test::current_task().unwrap().tid()));
-        syscall::system_tick();
-        assert!(test::current_task().is_some());
-        assert_eq!(handle_2.tid(), Ok(test::current_task().unwrap().tid()));
-
-        // Now it's done with the lock, so it releases
-        drop(guard);
-        assert_eq!(mutex.lock.load(Ordering::Relaxed), false);
-
-        // Next context switch should go back to task 1, where theoretically it would
-        // acquire the lock
+        assert_eq!(handle_1.tid(), Ok(test::current_task().unwrap().tid()));
         syscall::system_tick();
         assert!(test::current_task().is_some());
         assert_eq!(handle_1.tid(), Ok(test::current_task().unwrap().tid()));
+        syscall::system_tick();
+        assert!(test::current_task().is_some());
+        assert_eq!(handle_1.tid(), Ok(test::current_task().unwrap().tid()));
+
+        // Now it's done with the lock, so it releases
+        drop(guard);
+        assert_eq!(mutex.lock.lock.load(Ordering::Relaxed), UNLOCKED);
+
+        // Next context switch should go back to task 2, where theoretically it would
+        // acquire the lock
+        syscall::system_tick();
+        assert!(test::current_task().is_some());
+        assert_eq!(handle_2.tid(), Ok(test::current_task().unwrap().tid()));
     }
 
     #[test]
@@ -267,46 +407,45 @@ mod tests {
 
         let guard = mutex.lock();
 
+        syscall::sched_yield();
+
         // See above test for details
-        // First task fails to acquire lock
-        syscall::sleep(mutex.wchan());
-        assert_eq!(handle_1.state(), Ok(State::Blocked));
-        assert!(test::current_task().is_some());
-        assert_eq!(handle_2.tid(), Ok(test::current_task().unwrap().tid()));
         // Second task fails to acquire lock
-        syscall::sleep(mutex.wchan());
+        syscall::sleep(mutex.lock.address());
         assert_eq!(handle_2.state(), Ok(State::Blocked));
         assert!(test::current_task().is_some());
         assert_eq!(handle_3.tid(), Ok(test::current_task().unwrap().tid()));
         // Third task fails to acquire lock
-        syscall::sleep(mutex.wchan());
+        syscall::sleep(mutex.lock.address());
         assert_eq!(handle_3.state(), Ok(State::Blocked));
         assert!(test::current_task().is_some());
         assert_eq!(handle_4.tid(), Ok(test::current_task().unwrap().tid()));
-
-        // Task 4 holds the lock, lets context switch a few times
-        syscall::system_tick();
+        // Fourth task fails to acquire lock
+        syscall::sleep(mutex.lock.address());
+        assert_eq!(handle_4.state(), Ok(State::Blocked));
         assert!(test::current_task().is_some());
-        assert_eq!(handle_4.tid(), Ok(test::current_task().unwrap().tid()));
-        syscall::system_tick();
-        assert!(test::current_task().is_some());
-        assert_eq!(handle_4.tid(), Ok(test::current_task().unwrap().tid()));
-        syscall::system_tick();
-        assert!(test::current_task().is_some());
-        assert_eq!(handle_4.tid(), Ok(test::current_task().unwrap().tid()));
+        assert_eq!(handle_1.tid(), Ok(test::current_task().unwrap().tid()));
 
-        // Release the lock
-        drop(guard);
-        assert_ne!(handle_1.state(), Ok(State::Blocked));
-        assert_ne!(handle_2.state(), Ok(State::Blocked));
-        assert_ne!(handle_3.state(), Ok(State::Blocked));
-
-        // Make sure each task can get scheduled
+        // Task 1 holds the lock, lets context switch a few times
         syscall::system_tick();
         assert!(test::current_task().is_some());
         assert_eq!(handle_1.tid(), Ok(test::current_task().unwrap().tid()));
         syscall::system_tick();
         assert!(test::current_task().is_some());
+        assert_eq!(handle_1.tid(), Ok(test::current_task().unwrap().tid()));
+        syscall::system_tick();
+        assert!(test::current_task().is_some());
+        assert_eq!(handle_1.tid(), Ok(test::current_task().unwrap().tid()));
+
+        // Release the lock
+        drop(guard);
+        assert_ne!(handle_2.state(), Ok(State::Blocked));
+        assert_ne!(handle_3.state(), Ok(State::Blocked));
+        assert_ne!(handle_4.state(), Ok(State::Blocked));
+
+        // Make sure each task can get scheduled
+        syscall::system_tick();
+        assert!(test::current_task().is_some());
         assert_eq!(handle_2.tid(), Ok(test::current_task().unwrap().tid()));
         syscall::system_tick();
         assert!(test::current_task().is_some());
@@ -314,11 +453,17 @@ mod tests {
         syscall::system_tick();
         assert!(test::current_task().is_some());
         assert_eq!(handle_4.tid(), Ok(test::current_task().unwrap().tid()));
+        syscall::system_tick();
+        assert!(test::current_task().is_some());
+        assert_eq!(handle_1.tid(), Ok(test::current_task().unwrap().tid()));
     }
 
     #[test]
     fn test_mutex_guard_derefrences_to_owned_data() {
+        let _g = test::set_up();
         let mutex = Mutex::new(0);
+        sched::start_scheduler();
+
         let mut guard = mutex.lock();
 
         *guard = 100;

--- a/altos-rust/altos-core/src/syscall/mod.rs
+++ b/altos-rust/altos-core/src/syscall/mod.rs
@@ -515,11 +515,9 @@ mod tests {
         let (handle_1, handle_2) = test::create_two_tasks();
 
         start_scheduler();
-        assert!(test::current_task().is_some());
         assert_eq!(handle_1.tid(), Ok(test::current_task().unwrap().tid()));
 
         sched_yield();
-        assert!(test::current_task().is_some());
         assert_eq!(handle_2.tid(), Ok(test::current_task().unwrap().tid()));
     }
 
@@ -529,21 +527,17 @@ mod tests {
         let (handle_1, handle_2) = test::create_two_tasks();
 
         start_scheduler();
-        assert!(test::current_task().is_some());
         assert_eq!(handle_1.tid(), Ok(test::current_task().unwrap().tid()));
 
         // There's some special logic when something sleeps on FOREVER_CHAN, so make sure we don't
         // sleep on it
         sleep(!FOREVER_CHAN);
-        assert!(test::current_task().is_some());
         assert_eq!(handle_2.tid(), Ok(test::current_task().unwrap().tid()));
 
         sched_yield();
-        assert!(test::current_task().is_some());
         assert_eq!(handle_2.tid(), Ok(test::current_task().unwrap().tid()));
 
         sched_yield();
-        assert!(test::current_task().is_some());
         assert_eq!(handle_2.tid(), Ok(test::current_task().unwrap().tid()));
     }
 
@@ -553,19 +547,16 @@ mod tests {
         let (handle_1, handle_2) = test::create_two_tasks();
 
         start_scheduler();
-        assert!(test::current_task().is_some());
         assert_eq!(handle_1.tid(), Ok(test::current_task().unwrap().tid()));
 
         // There's some special logic when something sleeps on FOREVER_CHAN, so make sure we don't
         // sleep on it
         sleep(!FOREVER_CHAN);
         assert_eq!(handle_1.state(), Ok(State::Blocked));
-        assert!(test::current_task().is_some());
         assert_eq!(handle_2.tid(), Ok(test::current_task().unwrap().tid()));
 
         sched_yield();
         assert_eq!(handle_1.state(), Ok(State::Blocked));
-        assert!(test::current_task().is_some());
         assert_eq!(handle_2.tid(), Ok(test::current_task().unwrap().tid()));
 
 
@@ -575,7 +566,6 @@ mod tests {
         assert_eq!(handle_2.tid(), Ok(test::current_task().unwrap().tid()));
 
         sched_yield();
-        assert!(test::current_task().is_some());
         assert_eq!(handle_1.tid(), Ok(test::current_task().unwrap().tid()));
     }
 
@@ -585,13 +575,11 @@ mod tests {
         let (handle_1, handle_2) = test::create_two_tasks();
 
         start_scheduler();
-        assert!(test::current_task().is_some());
         assert_eq!(handle_1.tid(), Ok(test::current_task().unwrap().tid()));
 
         let old_tick = tick::get_tick();
         system_tick();
         assert_eq!(old_tick + 1, tick::get_tick());
-        assert!(test::current_task().is_some());
         assert_eq!(handle_2.tid(), Ok(test::current_task().unwrap().tid()));
     }
 
@@ -601,37 +589,30 @@ mod tests {
         let (handle_1, handle_2) = test::create_two_tasks();
 
         start_scheduler();
-        assert!(test::current_task().is_some());
         assert_eq!(handle_1.tid(), Ok(test::current_task().unwrap().tid()));
 
         sleep_for(FOREVER_CHAN, 4);
         assert_eq!(handle_1.state(), Ok(State::Blocked));
-        assert!(test::current_task().is_some());
         assert_eq!(handle_2.tid(), Ok(test::current_task().unwrap().tid()));
 
         system_tick();
         assert_eq!(handle_1.state(), Ok(State::Blocked));
-        assert!(test::current_task().is_some());
         assert_eq!(handle_2.tid(), Ok(test::current_task().unwrap().tid()));
 
         system_tick();
         assert_eq!(handle_1.state(), Ok(State::Blocked));
-        assert!(test::current_task().is_some());
         assert_eq!(handle_2.tid(), Ok(test::current_task().unwrap().tid()));
 
         system_tick();
         assert_eq!(handle_1.state(), Ok(State::Blocked));
-        assert!(test::current_task().is_some());
         assert_eq!(handle_2.tid(), Ok(test::current_task().unwrap().tid()));
 
         system_tick();
         // 4 Ticks have passed, task 1 should be woken up now
         assert_ne!(handle_1.state(), Ok(State::Blocked));
-        assert!(test::current_task().is_some());
         assert_eq!(handle_1.tid(), Ok(test::current_task().unwrap().tid()));
 
         system_tick();
-        assert!(test::current_task().is_some());
         assert_eq!(handle_2.tid(), Ok(test::current_task().unwrap().tid()));
     }
 
@@ -641,37 +622,30 @@ mod tests {
         let (handle_1, handle_2) = test::create_two_tasks();
 
         start_scheduler();
-        assert!(test::current_task().is_some());
         assert_eq!(handle_1.tid(), Ok(test::current_task().unwrap().tid()));
 
         sleep_for(!FOREVER_CHAN, 4);
         assert_eq!(handle_1.state(), Ok(State::Blocked));
-        assert!(test::current_task().is_some());
         assert_eq!(handle_2.tid(), Ok(test::current_task().unwrap().tid()));
 
         system_tick();
         assert_eq!(handle_1.state(), Ok(State::Blocked));
-        assert!(test::current_task().is_some());
         assert_eq!(handle_2.tid(), Ok(test::current_task().unwrap().tid()));
 
         system_tick();
         assert_eq!(handle_1.state(), Ok(State::Blocked));
-        assert!(test::current_task().is_some());
         assert_eq!(handle_2.tid(), Ok(test::current_task().unwrap().tid()));
 
         system_tick();
         assert_eq!(handle_1.state(), Ok(State::Blocked));
-        assert!(test::current_task().is_some());
         assert_eq!(handle_2.tid(), Ok(test::current_task().unwrap().tid()));
 
         system_tick();
         // 4 Ticks have passed, task 1 should be woken up now
         assert_ne!(handle_1.state(), Ok(State::Blocked));
-        assert!(test::current_task().is_some());
         assert_eq!(handle_1.tid(), Ok(test::current_task().unwrap().tid()));
 
         system_tick();
-        assert!(test::current_task().is_some());
         assert_eq!(handle_2.tid(), Ok(test::current_task().unwrap().tid()));
     }
 
@@ -681,17 +655,14 @@ mod tests {
         let (handle_1, handle_2) = test::create_two_tasks();
 
         start_scheduler();
-        assert!(test::current_task().is_some());
         assert_eq!(handle_1.tid(), Ok(test::current_task().unwrap().tid()));
 
         sleep_for(!FOREVER_CHAN, 4);
         assert_eq!(handle_1.state(), Ok(State::Blocked));
-        assert!(test::current_task().is_some());
         assert_eq!(handle_2.tid(), Ok(test::current_task().unwrap().tid()));
 
         system_tick();
         assert_eq!(handle_1.state(), Ok(State::Blocked));
-        assert!(test::current_task().is_some());
         assert_eq!(handle_2.tid(), Ok(test::current_task().unwrap().tid()));
 
         wake(!FOREVER_CHAN);
@@ -699,7 +670,6 @@ mod tests {
         assert_eq!(handle_2.tid(), Ok(test::current_task().unwrap().tid()));
 
         system_tick();
-        assert!(test::current_task().is_some());
         assert_eq!(handle_1.tid(), Ok(test::current_task().unwrap().tid()));
     }
 
@@ -709,19 +679,276 @@ mod tests {
         let (handle_1, handle_2) = test::create_two_tasks();
 
         start_scheduler();
-        assert!(test::current_task().is_some());
         assert_eq!(handle_1.tid(), Ok(test::current_task().unwrap().tid()));
 
         // This should yield the task but immediately wake up on the next tick
         sleep_for(FOREVER_CHAN, 0);
         assert_eq!(handle_1.state(), Ok(State::Blocked));
-        assert!(test::current_task().is_some());
         assert_eq!(handle_2.tid(), Ok(test::current_task().unwrap().tid()));
 
         system_tick();
         assert_ne!(handle_1.state(), Ok(State::Blocked));
-        assert!(test::current_task().is_some());
         assert_eq!(handle_1.tid(), Ok(test::current_task().unwrap().tid()));
+    }
+
+    #[test]
+    fn test_mutex_lock() {
+        let _g = test::set_up();
+        let raw_mutex = RawMutex::new();
+        let handle = new_task(test_task, Args::empty(), 512, Priority::Normal, "test creation task");
+
+        start_scheduler();
+        assert_eq!(handle.tid(), Ok(test::current_task().unwrap().tid()));
+
+        // We should not be blocked after this call
+        mutex_lock(&raw_mutex);
+        assert_eq!(handle.tid(), Ok(test::current_task().unwrap().tid()));
+        assert_eq!(handle.tid().ok(), raw_mutex.holder());
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_mutex_lock_twice_with_same_task_id_panics() {
+        let _g = test::set_up();
+        let raw_mutex = RawMutex::new();
+        let handle = new_task(test_task, Args::empty(), 512, Priority::Normal, "test creation task");
+
+        start_scheduler();
+        assert_eq!(handle.tid(), Ok(test::current_task().unwrap().tid()));
+
+        // We should not be blocked after this call
+        mutex_lock(&raw_mutex);
+        assert_eq!(handle.tid(), Ok(test::current_task().unwrap().tid()));
+        assert_eq!(handle.tid().ok(), raw_mutex.holder());
+
+        mutex_lock(&raw_mutex);
+    }
+
+    // Hm... this test always fails because the second `mutex_lock` call should put the second task
+    // to sleep and block until the lock is acquired... But because it's blocking we can never get
+    // past that function call, so the scheduler just keeps trying to schedule tasks until it runs
+    // out of tasks to schedule. I'm not so sure how to solve this since this is the behavior that
+    // we want...
+    #[test]
+    #[ignore]
+    fn test_mutex_lock_while_locked_sleeps_current_task() {
+        let _g = test::set_up();
+        let raw_mutex = RawMutex::new();
+        let (handle_1, handle_2) = test::create_two_tasks();
+
+        start_scheduler();
+        assert_eq!(handle_1.tid(), Ok(test::current_task().unwrap().tid()));
+
+        // We should not be blocked after this call
+        mutex_lock(&raw_mutex);
+        assert_eq!(handle_1.tid(), Ok(test::current_task().unwrap().tid()));
+        assert_eq!(handle_1.tid().ok(), raw_mutex.holder());
+
+        // Switch to task 2 while task 1 holds lock
+        sched_yield();
+        assert_eq!(handle_2.tid(), Ok(test::current_task().unwrap().tid()));
+
+        mutex_lock(&raw_mutex);
+        assert_eq!(handle_1.tid(), Ok(test::current_task().unwrap().tid()));
+        assert_eq!(handle_2.state(), Ok(State::Blocked));
+    }
+
+    #[test]
+    fn test_mutex_try_lock() {
+        let _g = test::set_up();
+        let raw_mutex = RawMutex::new();
+        let handle = new_task(test_task, Args::empty(), 512, Priority::Normal, "test creation task");
+
+        start_scheduler();
+        assert_eq!(handle.tid(), Ok(test::current_task().unwrap().tid()));
+
+        assert_eq!(mutex_try_lock(&raw_mutex), true);
+    }
+
+    #[test]
+    fn test_mutex_try_lock_while_locked_returns_false() {
+        let _g = test::set_up();
+        let raw_mutex = RawMutex::new();
+        let (handle_1, handle_2) = test::create_two_tasks();
+
+        start_scheduler();
+        assert_eq!(handle_1.tid(), Ok(test::current_task().unwrap().tid()));
+
+        assert_eq!(mutex_try_lock(&raw_mutex), true);
+
+        // Switch to task 2 while task 1 holds lock
+        sched_yield();
+        assert_eq!(handle_2.tid(), Ok(test::current_task().unwrap().tid()));
+
+        assert_eq!(mutex_try_lock(&raw_mutex), false);
+    }
+
+    #[test]
+    fn test_mutex_try_lock_while_holding_lock_returns_true() {
+        let _g = test::set_up();
+        let raw_mutex = RawMutex::new();
+        let handle = new_task(test_task, Args::empty(), 512, Priority::Normal, "test creation task");
+
+        start_scheduler();
+        assert_eq!(handle.tid(), Ok(test::current_task().unwrap().tid()));
+
+        assert_eq!(mutex_try_lock(&raw_mutex), true);
+        assert_eq!(mutex_try_lock(&raw_mutex), true);
+    }
+
+    #[test]
+    fn test_mutex_unlock() {
+        let _g = test::set_up();
+        let raw_mutex = RawMutex::new();
+
+        let handle = new_task(test_task, Args::empty(), 512, Priority::Normal, "test creation task");
+
+        start_scheduler();
+        assert_eq!(handle.tid(), Ok(test::current_task().unwrap().tid()));
+
+        mutex_lock(&raw_mutex);
+        assert_eq!(handle.tid().ok(), raw_mutex.holder());
+
+        mutex_unlock(&raw_mutex);
+        assert!(raw_mutex.holder().is_none());
+    }
+
+    #[test]
+    fn test_mutex_unlock_while_unlocked_is_noop() {
+        let _g = test::set_up();
+        let raw_mutex = RawMutex::new();
+
+        start_scheduler();
+
+        assert!(raw_mutex.holder().is_none());
+
+        mutex_unlock(&raw_mutex);
+        assert!(raw_mutex.holder().is_none());
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_mutex_unlock_while_not_holding_panics() {
+        let _g = test::set_up();
+        let raw_mutex = RawMutex::new();
+
+        let (handle_1, handle_2) = test::create_two_tasks();
+
+        start_scheduler();
+        assert_eq!(handle_1.tid(), Ok(test::current_task().unwrap().tid()));
+
+        mutex_lock(&raw_mutex);
+        assert_eq!(handle_1.tid().ok(), raw_mutex.holder());
+
+        sched_yield();
+        assert_eq!(handle_2.tid(), Ok(test::current_task().unwrap().tid()));
+
+        mutex_unlock(&raw_mutex);
+    }
+
+    #[test]
+    fn test_mutex_unlock_wakes_sleeping_tasks() {
+        let _g = test::set_up();
+        let raw_mutex = RawMutex::new();
+
+        let (handle_1, handle_2) = test::create_two_tasks();
+
+        start_scheduler();
+        assert_eq!(handle_1.tid(), Ok(test::current_task().unwrap().tid()));
+
+        mutex_lock(&raw_mutex);
+        assert_eq!(handle_1.tid().ok(), raw_mutex.holder());
+
+        sched_yield();
+        assert_eq!(handle_2.tid(), Ok(test::current_task().unwrap().tid()));
+
+        // Simulate blocking on acquiring the lock
+        sleep(raw_mutex.address());
+        assert_eq!(handle_2.state(), Ok(State::Blocked));
+        assert_eq!(handle_1.tid(), Ok(test::current_task().unwrap().tid()));
+
+        mutex_unlock(&raw_mutex);
+        assert_eq!(handle_2.state(), Ok(State::Ready));
+
+        // Task 2 can be scheduled again
+        sched_yield();
+        assert_eq!(handle_2.tid(), Ok(test::current_task().unwrap().tid()));
+    }
+
+    #[test]
+    fn test_condvar_wait() {
+        let _g = test::set_up();
+        let raw_mutex = RawMutex::new();
+        let cond_var = CondVar::new();
+
+        let handle = new_task(test_task, Args::empty(), 512, Priority::Normal, "test creation task");
+
+        start_scheduler();
+        assert_eq!(handle.tid(), Ok(test::current_task().unwrap().tid()));
+
+        mutex_lock(&raw_mutex);
+        assert_eq!(handle.tid().ok(), raw_mutex.holder());
+
+        condvar_wait(&cond_var, &raw_mutex);
+        assert_eq!(handle.state(), Ok(State::Blocked));
+    }
+
+    #[test]
+    fn test_condvar_wait_using_unlocked_lock_succeeds() {
+        let _g = test::set_up();
+        let raw_mutex = RawMutex::new();
+        let cond_var = CondVar::new();
+
+        let handle = new_task(test_task, Args::empty(), 512, Priority::Normal, "test creation task");
+
+        start_scheduler();
+        assert_eq!(handle.tid(), Ok(test::current_task().unwrap().tid()));
+
+        condvar_wait(&cond_var, &raw_mutex);
+        assert_eq!(handle.state(), Ok(State::Blocked));
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_condvar_wait_using_unacquired_lock_panics() {
+        let _g = test::set_up();
+        let raw_mutex = RawMutex::new();
+        let cond_var = CondVar::new();
+
+        let (handle_1, handle_2) = test::create_two_tasks();
+
+        start_scheduler();
+        assert_eq!(handle_1.tid(), Ok(test::current_task().unwrap().tid()));
+
+        mutex_lock(&raw_mutex);
+        assert_eq!(handle_1.tid().ok(), raw_mutex.holder());
+
+        // Switch to Task 2 while Task 1 holds the lock
+        sched_yield();
+        assert_eq!(handle_2.tid(), Ok(test::current_task().unwrap().tid()));
+
+        condvar_wait(&cond_var, &raw_mutex);
+    }
+
+    #[test]
+    fn test_condvar_broadcast_wakes_waiting_tasks() {
+        let _g = test::set_up();
+        let raw_mutex = RawMutex::new();
+        let cond_var = CondVar::new();
+
+        let handle = new_task(test_task, Args::empty(), 512, Priority::Normal, "test creation task");
+
+        start_scheduler();
+        assert_eq!(handle.tid(), Ok(test::current_task().unwrap().tid()));
+
+        mutex_lock(&raw_mutex);
+        assert_eq!(handle.tid().ok(), raw_mutex.holder());
+
+        condvar_wait(&cond_var, &raw_mutex);
+        assert_eq!(handle.state(), Ok(State::Blocked));
+
+        condvar_broadcast(&cond_var);
+        assert_eq!(handle.state(), Ok(State::Ready));
     }
 
     // Stub used for new_task calls.

--- a/altos-rust/altos-core/src/task/control.rs
+++ b/altos-rust/altos-core/src/task/control.rs
@@ -233,9 +233,9 @@ pub struct TaskControl {
     tid: usize,
     name: &'static str,
     valid: usize,
-    pub wchan: usize,
-    pub delay: usize,
-    pub delay_type: Delay,
+    wchan: usize,
+    delay: usize,
+    delay_type: Delay,
     pub destroy: bool,
     pub priority: Priority,
     pub state: State,
@@ -300,7 +300,60 @@ impl TaskControl {
         self.stack.check_overflow()
     }
 
+    pub fn set_ready(&mut self) {
+        self.state = State::Ready;
+        self.delay_type = Delay::Invalid;
+    }
+
+    pub fn block(&mut self, delay_type: Delay) {
+        self.state = State::Blocked;
+        self.delay_type = delay_type;
+    }
+
+    /// Wake a sleeping task
+    ///
+    /// Set a task to the `Ready` state from the `Blocked` state.
+    pub fn wake(&mut self) {
+        debug_assert!(self.state == State::Blocked);
+        self.set_ready();
+        self.wchan = 0;
+        self.delay = 0;
+    }
+
+    /// Put a task to sleep without timeout
+    ///
+    /// The task will sleep on `wchan` until woken up. If a wake signal is never received the task
+    /// will never awaken.
+    pub fn sleep(&mut self, wchan: usize) {
+        debug_assert!(self.state == State::Running);
+        self.block(Delay::Sleep);
+        self.wchan = wchan;
+    }
+
+    /// Put a task to sleep
+    ///
+    /// The task will sleep on `wchan` until woken up or until a number of ticks > `delay` has
+    /// passed. The task is guaranteed to wake up eventually.
+    pub fn sleep_for(&mut self, wchan: usize, delay: usize) {
+        debug_assert!(self.state == State::Running);
+        let ticks = ::tick::get_tick();
+        self.wchan = wchan;
+        self.delay = ticks.wrapping_add(delay);
+        if self.delay < ticks {
+            self.block(Delay::Overflowed);
+        }
+        else {
+            self.block(Delay::Timeout);
+        }
+    }
+
     pub fn tid(&self) -> usize { self.tid }
+
+    pub fn wchan(&self) -> usize { self.wchan }
+
+    pub fn tick_to_wake(&self) -> usize { self.delay }
+
+    pub fn delay_type(&self) -> Delay { self.delay_type }
 }
 
 /// A `TaskHandle` references a `TaskControl` and provides access to some state about it.
@@ -399,11 +452,11 @@ impl TaskHandle {
     ///
     /// If the task has been destroyed then this method will return an `Err(())`.
     pub fn priority(&self) -> HandleResult<Priority> {
-        let _g = CriticalSection::begin();
+        let priority = self.task_ref().priority;
         if self.is_valid() {
-            let task = self.task_ref();
-            Ok(task.priority)
-        } else {
+            Ok(priority)
+        }
+        else {
             Err(())
         }
     }
@@ -435,10 +488,9 @@ impl TaskHandle {
     ///
     /// If the task has been destroyed then this method will return an `Err(())`.
     pub fn state(&self) -> HandleResult<State> {
-        let _g = CriticalSection::begin();
+        let state = self.task_ref().state;
         if self.is_valid() {
-            let task = self.task_ref();
-            Ok(task.state)
+            Ok(state)
         } else {
             Err(())
         }
@@ -472,10 +524,9 @@ impl TaskHandle {
     ///
     /// If the task has been destroyed then this method will return an `Err(())`.
     pub fn tid(&self) -> HandleResult<usize> {
-        let _g = CriticalSection::begin();
+        let tid = self.task_ref().tid;
         if self.is_valid() {
-            let task = self.task_ref();
-            Ok(task.tid)
+            Ok(tid)
         } else {
             Err(())
         }
@@ -504,10 +555,9 @@ impl TaskHandle {
     ///
     /// If the task has been destroyed then this method will return an `Err(())`.
     pub fn name(&self) -> HandleResult<&'static str> {
-        let _g = CriticalSection::begin();
+        let name = self.task_ref().name;
         if self.is_valid() {
-            let task = self.task_ref();
-            Ok(task.name)
+            Ok(name)
         } else {
             Err(())
         }
@@ -538,10 +588,9 @@ impl TaskHandle {
     ///
     /// If the task has been destroyed then this method will return an `Err(())`.
     pub fn stack_size(&self) -> HandleResult<usize> {
-        let _g = CriticalSection::begin();
+        let size = self.task_ref().stack.depth();
         if self.is_valid() {
-            let task = self.task_ref();
-            Ok(task.stack.depth())
+            Ok(size)
         } else {
             Err(())
         }

--- a/altos-rust/altos-core/src/task/mod.rs
+++ b/altos-rust/altos-core/src/task/mod.rs
@@ -37,7 +37,7 @@ pub fn init_idle_task() {
 
     let task = TaskControl::new(idle_task_code, Args::empty(), INIT_TASK_STACK_SIZE, Priority::__Idle, "idle");
 
-    PRIORITY_QUEUES[task.priority].enqueue(Box::new(Node::new(task)));
+    PRIORITY_QUEUES[task.priority()].enqueue(Box::new(Node::new(task)));
 }
 
 fn idle_task_code(_args: &mut Args) {

--- a/altos-rust/altos-core/src/test.rs
+++ b/altos-rust/altos-core/src/test.rs
@@ -66,8 +66,7 @@ pub fn current_task() -> Option<&'static mut TaskControl> {
 }
 
 pub fn block_current_task(delay_type: Delay) {
-    current_task().unwrap().state = State::Blocked;
-    current_task().unwrap().delay_type = delay_type;
+    current_task().unwrap().block(delay_type);
 }
 
 pub fn create_two_tasks() -> (TaskHandle, TaskHandle) {

--- a/altos-rust/altos-core/src/test.rs
+++ b/altos-rust/altos-core/src/test.rs
@@ -27,7 +27,7 @@ use sched::{CURRENT_TASK, SLEEP_QUEUE, DELAY_QUEUE,
             OVERFLOW_DELAY_QUEUE, PRIORITY_QUEUES, NORMAL_TASK_COUNTER};
 
 use sync::{SpinMutex, SpinGuard};
-use task::{Priority, TaskControl, TaskHandle, State, Delay};
+use task::{Priority, TaskControl, TaskHandle, Delay};
 use task::args::Args;
 use atomic::Ordering;
 


### PR DESCRIPTION
Refactored a lot of the task functionality so it's more self-contained within the `task` module rather than spread around the `task`, `sched`, and `syscall` modules. This should make it easier to maintain if we ever want to change behavior of tasks.

Also changed the `Mutex` and `CondVar` types to use system calls for their functionality, this gives the kernel more fine grained control over how these synchronization primitives work, and allows for better error handling (deadlock detection, for instance).

The `RawMutex` type was added to help facilitate changes to both synchronization primitives, which handles the logic behind acquiring and releasing locks at the lowest level. This type behaves much like a mutex from synchronization libraries in C, where it doesn't give access to a specific resource and it must be explicitly unlocked when it is done being used. It's not meant for user level applications, though it can be used there if more control is desired by an application.

@RJ-Russell 