### PR TITLE
Update `volatile` crate for more ergonomic use

### DIFF
--- a/altos-rust/libs/volatile/Cargo.toml
+++ b/altos-rust/libs/volatile/Cargo.toml
@@ -1,7 +1,13 @@
 [package]
-name = "volatile"
-version = "0.1.0"
+name = "volatile-ptr"
+version = "0.1.1"
+documentation = "https://docs.rs/volatile-ptr"
 authors = ["Daniel Seitz <dnseitz@gmail.com>"]
+description = "Implementation of volatile pointers for I/O device access"
+repository = "https://github.com/AltOS-Rust/volatile"
+keywords = ["volatile", "pointer", "embedded", "hardware", "memory"]
+categories = ["embedded", "hardware-support", "memory-management", "no-std", "os"]
+license = "GPL-3.0"
 
 [lib]
 crate-type = ["rlib"]

--- a/altos-rust/libs/volatile/src/tests.rs
+++ b/altos-rust/libs/volatile/src/tests.rs
@@ -20,6 +20,18 @@
 use super::Volatile;
 
 #[test]
+fn test_volatile_from_ref_is_safe() {
+    let num = 0x1000;
+    let _ = Volatile::from(&num);
+}
+
+#[test]
+fn test_volatile_from_mut_ref_is_safe() {
+    let mut num = 0x1000;
+    let _ = Volatile::from(&mut num);
+}
+
+#[test]
 fn test_ptr_positive_offset() {
     unsafe {
         let ptr = Volatile::new(100 as *const u32);
@@ -62,6 +74,44 @@ fn test_load_volatile() {
         let volatile = Volatile::new(&num);
         assert_eq!(num, volatile.load());
     }
+}
+
+#[test]
+fn test_modify_volatile() {
+    let num = 0x00;
+    unsafe {
+        let mut volatile = Volatile::new(&num);
+        volatile.modify(|x| {
+            *x = 0xAAAA;
+        });
+    }
+    assert_eq!(num, 0xAAAA);
+}
+
+#[test]
+fn test_volatile_field_access() {
+    struct Test {
+        a: u32,
+        b: u32,
+    }
+    let test = Test { a: 0, b: 0 };
+    unsafe {
+        let mut volatile = Volatile::new(&test);
+        volatile.a = 0x1234;
+        volatile.b = 0x5678;
+    }
+    assert_eq!(test.a, 0x1234);
+    assert_eq!(test.b, 0x5678);
+}
+
+#[test]
+fn test_assign_volatile_deref() {
+    let num = 0x00;
+    unsafe {
+        let mut volatile = Volatile::new(&num);
+        *volatile = 0xFFFF;
+    }
+    assert_eq!(num, 0xFFFF);
 }
 
 #[test]


### PR DESCRIPTION
@RJ-Russell 

This alters the `volatile` crate to try and make it behave exactly like
raw pointers. Dereferencing the pointer should be treated as a volatile
operation by the compiler and force a load or store of the value from
memory.

These changes remove the `RawVolatile` backing type that was being used
to implement basic operations for the pointed at value. Now the `Deref`
and `DerefMut` traits of the `Volatile` type just directly dereference
the stored pointer. The volatile behavior is achieved through a little
assembly trick, inserting a

```rust
asm!("" ::: "memory" : "volatile");
```

macro tricks the compilier into believing that some assembly
instructions were generated that touched main memory, and so any loads
and stores after that must reach out to main memory again. This isn't
neccessarily ideal since it could inhibit some compiler optimizations
that would otherwise be fine, but the ease of use it provides seems like
a much greater benefit.